### PR TITLE
Fix Client model mapping in UpdateClient

### DIFF
--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/client/UpdateClientAction.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/client/UpdateClientAction.kt
@@ -59,8 +59,8 @@ class UpdateClientAction(
             oldClient.access,
             baseUrl ?: oldClient.baseUrl,
             adminUrl ?: oldClient.adminUrl,
-            rootUrl ?: oldClient.rootUrl,
-            oldClient.secret)
+            oldClient.secret,
+        rootUrl ?: oldClient.rootUrl)
 
     override fun execute() {
         if (!client.existsClient(clientId, realm())) {


### PR DESCRIPTION
Hi,

Thanks for the project and the contribution, super stable and complete.
I'm using this as part of my OCP GitOps installation; see [here](https://github.com/adetalhouet/ocp-gitops/tree/main/apps/06-rhsso/overlay/default/config) for reference.

The `secret` and `rootUrl` are in inversed order, as per as the [model defined here](https://github.com/mayope/keycloakmigration/blob/master/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/model/Client.kt#L37-L38), resulting in a wrongly configured client-secret down the road.

I haven't added any test, nor find that many tests in that area to validate model mapping, but as I faced this issue today, I figure I'll at least submit the PR to track it.

Let me know if you wish I add tests surrounding this.

Cheers