### PR TITLE
Stability in token holder

### DIFF
--- a/docsbuild/content/migrations/role.md
+++ b/docsbuild/content/migrations/role.md
@@ -11,7 +11,7 @@ All migrations referring to the role resource.
 Add a role to keycloak, fails if the role already exists
 ### Parameter
 - realm: String, optional
-- name: String, mandatory,
+- name: String, not optional,
 - clientId: String, optional, default=realmRole,
 - description: String, optional, default=""
 - attributes: Map< String,List< String>>, optional, default=empty

--- a/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/KeycloakClientInit.kt
+++ b/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/KeycloakClientInit.kt
@@ -8,6 +8,8 @@ import feign.Logger
 import feign.form.FormEncoder
 import feign.jackson.JacksonDecoder
 import feign.jackson.JacksonEncoder
+import java.util.function.Consumer
+import java.util.function.Supplier
 
 /**
  * Builds the [KeycloakClient]
@@ -18,18 +20,20 @@ import feign.jackson.JacksonEncoder
  * @param clientId id of the client to use for the login of the user
  */
 fun initKeycloakClient(baseUrl: String, adminUser: String, adminPassword: String, realm: String,
-                       clientId: String, logger: Logger? = null, totp:String="", tokenHolder: TokenHolder? = null) = Feign.builder().run {
+                       clientId: String, logger: Logger? = null, totp:String="", tokenRefreshTimeNs:Consumer<Supplier<Long>>? = null) = Feign.builder().run {
     val objectMapper = initObjectMapper()
-    val tokenHolder2 = tokenHolder ?: TokenHolder(
+    val tokenHolder = TokenHolder(
             initKeycloakLoginClient(objectMapper, baseUrl, logger),
             adminUser, adminPassword, realm, clientId,totp
     )
+    tokenRefreshTimeNs?.accept(Supplier { tokenHolder.tokenExpirationNs() })
+
     encoder(JacksonEncoder(objectMapper))
     decoder(JacksonDecoder(objectMapper.apply {
         configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     }))
     requestInterceptor {
-        tokenHolder2.token().run {
+        tokenHolder.token().run {
             it.header("Authorization", "Bearer $accessToken")
         }
     }
@@ -51,7 +55,7 @@ fun initKeycloakLoginClient(baseUrl: String, logger: Logger? = null): KeycloakLo
             initKeycloakLoginClient(it, baseUrl, logger)
         }
 
-fun initKeycloakLoginClient(objectMapper: ObjectMapper,
+internal fun initKeycloakLoginClient(objectMapper: ObjectMapper,
                                      baseUrl: String, logger: Logger? = null): KeycloakLoginClient = Feign.builder().run {
     encoder(FormEncoder(JacksonEncoder(objectMapper)))
     decoder(JacksonDecoder(objectMapper))

--- a/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/TokenHolder.kt
+++ b/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/TokenHolder.kt
@@ -9,23 +9,21 @@ import java.util.concurrent.TimeUnit.SECONDS
 /**
  * Manages the keycloak access tokens and refreshes if needed
  */
-class TokenHolder(private val client: KeycloakLoginClient,
+internal class TokenHolder(private val client: KeycloakLoginClient,
     private val adminUser: String, private val adminPassword: String,
     private val realm: String, private val clientId: String,
-    private val totp: String) {
+    private val totp: String, private val tokenRefreshOffsetMs: Long = 1000) {
 
     companion object {
         val LOG = LoggerFactory.getLogger(TokenHolder::class.java)!!
     }
 
-    private val safetyDurationMs = 1000
-
     private var token: AccessToken = client.login(realm, "password", clientId, adminUser, adminPassword, totp)
     private var tokenReceived: Long = currentTimeMillis()
     private var tokenReceivedNs: Long = nanoTime()
 
-    private fun tokenExpired() = currentTimeMillis() - tokenReceived > SECONDS.toMillis(token.expiresIn) - safetyDurationMs
-    private fun refreshExpired() = currentTimeMillis() - tokenReceived > SECONDS.toMillis(token.refreshExpiresIn) - safetyDurationMs
+    private fun tokenExpired() = currentTimeMillis() - tokenReceived > SECONDS.toMillis(token.expiresIn) - tokenRefreshOffsetMs
+    private fun refreshExpired() = currentTimeMillis() - tokenReceived > SECONDS.toMillis(token.refreshExpiresIn) - tokenRefreshOffsetMs
 
     fun tokenExpirationNs() = tokenReceivedNs + SECONDS.toNanos(token.expiresIn)
     fun tokenExpiration() = tokenReceived + SECONDS.toMillis(token.expiresIn)
@@ -35,6 +33,7 @@ class TokenHolder(private val client: KeycloakLoginClient,
             LOG.info("Token expired retrieving new one.")
             token = getNewToken()
             tokenReceived = currentTimeMillis()
+            tokenReceivedNs = nanoTime()
         }
         return token
     }

--- a/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/TokenHolder.kt
+++ b/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/TokenHolder.kt
@@ -18,12 +18,14 @@ class TokenHolder(private val client: KeycloakLoginClient,
         val LOG = LoggerFactory.getLogger(TokenHolder::class.java)!!
     }
 
+    private val safetyDurationMs = 1000
+
     private var token: AccessToken = client.login(realm, "password", clientId, adminUser, adminPassword, totp)
     private var tokenReceived: Long = currentTimeMillis()
     private var tokenReceivedNs: Long = nanoTime()
 
-    private fun tokenExpired() = currentTimeMillis() - tokenReceived > SECONDS.toMillis(token.expiresIn)
-    private fun refreshExpired() = currentTimeMillis() - tokenReceived > SECONDS.toMillis(token.refreshExpiresIn)
+    private fun tokenExpired() = currentTimeMillis() - tokenReceived > SECONDS.toMillis(token.expiresIn) - safetyDurationMs
+    private fun refreshExpired() = currentTimeMillis() - tokenReceived > SECONDS.toMillis(token.refreshExpiresIn) - safetyDurationMs
 
     fun tokenExpirationNs() = tokenReceivedNs + SECONDS.toNanos(token.expiresIn)
     fun tokenExpiration() = tokenReceived + SECONDS.toMillis(token.expiresIn)

--- a/src/test/kotlin/de/klg71/keycloakmigration/TokenFlakinessTest.kt
+++ b/src/test/kotlin/de/klg71/keycloakmigration/TokenFlakinessTest.kt
@@ -1,0 +1,72 @@
+package de.klg71.keycloakmigration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import de.klg71.keycloakmigration.changeControl.MigrationChangelogTest
+import de.klg71.keycloakmigration.keycloakapi.KeycloakClient
+import de.klg71.keycloakmigration.keycloakapi.TokenHolder
+import de.klg71.keycloakmigration.keycloakapi.initKeycloakClient
+import de.klg71.keycloakmigration.keycloakapi.initKeycloakLoginClient
+import de.klg71.keycloakmigration.keycloakapi.model.RealmUpdateBuilder
+import de.klg71.keycloakmigration.keycloakapi.model.User
+import de.klg71.keycloakmigration.keycloakapi.realmById
+import feign.slf4j.Slf4jLogger
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.slf4j.LoggerFactory
+import kotlin.test.fail
+
+class TokenFlakinessTest {
+
+    private val LOG = LoggerFactory.getLogger(MigrationChangelogTest::class.java)
+    private val feignLOG = Slf4jLogger(MigrationChangelogTest::class.java)
+
+    //@Test
+    fun testFlakiness() {
+        val masterTokenLifespan = 2000L
+
+        val baseUrl = "http://localhost:18080/auth"
+        val adminUser = "admin"
+        val realmName = "master"
+        val clientId = "admin-cli"
+        val adminPassword = "admin"
+        val objectMapper = ObjectMapper().registerModule(KotlinModule())!!
+
+        val configureClient = initKeycloakClient(baseUrl, adminUser, adminPassword, realmName, clientId, feignLOG)
+        val realm = configureClient.realmById(realmName)
+        val updatedRealm = RealmUpdateBuilder(realm).run {
+            this.accessTokenLifespan = masterTokenLifespan.toInt()/1000
+            this.accessTokenLifespanForImplicitFlow = masterTokenLifespan.toInt()/1000
+            build()
+        }
+        configureClient.updateRealm(realmName, updatedRealm)
+
+        repeat(10000) {
+            val preTokenTestDurationBeforeStartNs = 10L
+            val tokenHolder = TokenHolder(
+                    initKeycloakLoginClient(objectMapper, baseUrl, feignLOG),
+                    adminUser, adminPassword, realmName, clientId, ""
+            )
+            val client = initKeycloakClient(baseUrl, adminUser, adminPassword, realmName, clientId, feignLOG, tokenHolder = tokenHolder)
+
+            val testCallStartTimeNs = tokenHolder.tokenExpirationNs() - preTokenTestDurationBeforeStartNs
+            while (System.nanoTime() < testCallStartTimeNs) {
+            }
+            if (!testCall(client)) {
+                fail("keycloak call has failed!")
+            }
+        }
+    }
+
+    private fun testCall(client: KeycloakClient): Boolean {
+        try {
+            assertThat(client.searchByUsername("admin", "master").map(User::username))
+                    .containsExactlyInAnyOrder("admin")
+        } catch (ex: Throwable) {
+            LOG.error("testCall failed", ex)
+            return false
+        }
+        LOG.info("testCall done")
+        return true
+    }
+}


### PR DESCRIPTION
Hi.

Found a bug that appears rarely (once a day).

`
[ERROR] 2021-07-15 12:58:58.226 [main] KeycloakMigration - Error occurred while migrating: status 401 reading KeycloakClient#searchByUsername(String,String)
feign.FeignException: status 401 reading KeycloakClient#searchByUsername(String,String)
    at feign.FeignException.errorStatus(FeignException.java:78) ~[keycloakmigration.jar:?]
    at feign.codec.ErrorDecoder$Default.decode(ErrorDecoder.java:93) ~[keycloakmigration.jar:?]
    at feign.SynchronousMethodHandler.executeAndDecode(SynchronousMethodHandler.java:149) ~[keycloakmigration.jar:?]
    at feign.SynchronousMethodHandler.invoke(SynchronousMethodHandler.java:78) ~[keycloakmigration.jar:?]
    at feign.ReflectiveFeign$FeignInvocationHandler.invoke(ReflectiveFeign.java:103) ~[keycloakmigration.jar:?]
    at com.sun.proxy.$Proxy27.searchByUsername(Unknown Source) ~[?:?]
    at de.klg71.keycloakmigration.keycloakapi.KeycloakClientHelperKt.userByName(KeycloakClientHelper.kt:25) ~
`

I think that this error happens when TokenHolder doesn't refresh the token and sends an expired token to keycloak, and it is possible for TokenHolder not to refresh token near the expiration time where keycloak receives the message after the expiration time. 

Therefore created test that somehow proves that there is the problem - TokenFlakinessTest, but, to see the 401 problem, need to  comment out code related to safetyDurationMs in TokenHolder. Test execution time can also be 30 minutes.

Furthermore the only necessary change is in TokenHolder where safetyDurationMs is declared and used. Other lines are used only to make the test work. If the fix is only necessary then let me know, I will remove the test and make the code cleaner.
