### PR TITLE
chore: unify docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ plugins {
 
 Use the Tasks to execute the migration:
 #### Groovy
+```groovy
     task keycloakMigrateLocal(type: KeycloakMigrationTask) {
       group = "keycloak"
       description = "Migrate the keycloak instance"
@@ -34,8 +35,10 @@ Use the Tasks to execute the migration:
       failOnUndefinedVariables = false
       warnOnUndefinedVariables = true
     }
-    
+```
+
 ### Kotlin
+```kotlin
     register<KeycloakMigrationTask>("keycloakMigrateLocal") {
         group = "keycloak"
         description = "Migrate the keycloak instance"
@@ -54,7 +57,7 @@ Use the Tasks to execute the migration:
         failOnUndefinedVariables = false
         warnOnUndefinedVariables = true
     }
-    
+```
    To correct existing hashes please use the `KeycloakMigrationCorrectHashesTask`.
    
 ### Using the fatjar

--- a/docsbuild/content/_index.md
+++ b/docsbuild/content/_index.md
@@ -23,6 +23,8 @@ plugins {
 
 Use the Tasks to execute the migration:
 #### Groovy
+```groovy
+
     task keycloakMigrateLocal(type: KeycloakMigrationTask) {
       group = "keycloak"
       description = "Migrate the keycloak instance"
@@ -38,8 +40,9 @@ Use the Tasks to execute the migration:
       failOnUndefinedVariables = false
       warnOnUndefinedVariables = true
     }
-    
+```
 ### Kotlin
+```kotlin
     register<KeycloakMigrationTask>("keycloakMigrateLocal") {
         group = "keycloak"
         description = "Migrate the keycloak instance"
@@ -58,7 +61,7 @@ Use the Tasks to execute the migration:
         failOnUndefinedVariables = false
         warnOnUndefinedVariables = true
     }
-    
+```
    To correct existing hashes please use the `KeycloakMigrationCorrectHashesTask`.
    
 ### Using the fatjar

--- a/docsbuild/content/contributing.md
+++ b/docsbuild/content/contributing.md
@@ -18,7 +18,7 @@ If you want to contribute to this project please visit the [issues](https://gith
      compile group: 'de.klg71.keycloakmigration', name: 'keycloakmigration', version: 'x.x.x'
  ### Usage
  Kotlin
- 
+```kotlin
     class MyMigrationArgs(private val adminUser: String,
                           private val adminPassword: String,
                           private val migrationFile: String,
@@ -48,3 +48,4 @@ If you want to contribute to this project please visit the [issues](https://gith
         }
 
     }
+```

--- a/docsbuild/content/migration_files.md
+++ b/docsbuild/content/migration_files.md
@@ -16,12 +16,13 @@ Migrations are controlled through the changelog. It contains the changeSets used
     - relativeToFile: Boolean, optional, default=true, whether the file should be searched from the working dir or relative to the keycloak changelog file.
 
 #### Example
+```yaml
     includes:
       - path: 01_initial.yml
       - path: 02_second.yml
       - path: changes/03_third.yml
         relativeToFile: true
-
+```
 
 ### ChangeSet
 The changeSet contains the actual changes as a list of migrations (see [Supported Migrations]({{<ref "migrations" >}}))

--- a/docsbuild/content/migrations/_index.md
+++ b/docsbuild/content/migrations/_index.md
@@ -45,7 +45,7 @@ Tested with OpenJdk 12 and Keycloak 8.0.2
      compile group: 'de.klg71.keycloakmigration', name: 'keycloakmigration', version: 'x.x.x'
  ### Usage
  Kotlin
- 
+ ```kotlin
     class MyMigrationArgs(private val adminUser: String,
                           private val adminPassword: String,
                           private val migrationFile: String,
@@ -75,7 +75,7 @@ Tested with OpenJdk 12 and Keycloak 8.0.2
         }
 
     }
-
+```
 ## TODOS
 - Add more commands
 - Add sophisticated unit and integration Tests

--- a/docsbuild/content/migrations/client.md
+++ b/docsbuild/content/migrations/client.md
@@ -9,7 +9,7 @@ permalink: /migrations/client/
 All migrations referring to the client resource.
 ## addSimpleClient
 Simple command to add a client to keycloak, TODO: add more fields
-### Parameter
+### Parameters
 - realm: String, optional
 - clientId: String, not optional,
 - enabled: Boolean, optional, default=true
@@ -28,7 +28,7 @@ Simple command to add a client to keycloak, TODO: add more fields
 
 ## deleteClient
 Delete a client in keycloak
-### Parameter
+### Parameters
 - realm: String, optional
 - clientId: String, not optional,
 ### Example

--- a/docsbuild/content/migrations/client.md
+++ b/docsbuild/content/migrations/client.md
@@ -19,12 +19,14 @@ Simple command to add a client to keycloak, TODO: add more fields
 - publicClient: Boolean, optional, default=true
 - redirectUris: List< String>, optional, default=empty
 ### Example
+```yaml
     id: add-simple-client
     author: klg71
     changes:
     - addSimpleClient:
         realm: master
         clientId: test
+```
 
 ## deleteClient
 Delete a client in keycloak
@@ -32,12 +34,14 @@ Delete a client in keycloak
 - realm: String, optional
 - clientId: String, not optional,
 ### Example
+```yaml
     id: delete-client
     author: klg71
     changes:
     - deleteClient:
         realm: master
         clientId: test
+```
 
 ## importClient
 Imports a client using the json representation.
@@ -48,6 +52,7 @@ Imports a client using the json representation.
 - relativeToFile: Boolean, optional, default=true
 
 ### Example
+```yaml
     id: import-client
     author: klg71
     changes:
@@ -55,6 +60,7 @@ Imports a client using the json representation.
           realm: master
           clientRepresentationJsonFilename: client.json
           relativeToFile: true
+```
 
 ## updateClient
 Update a client
@@ -81,6 +87,7 @@ Update a client
 - fullScopeAllowed: Boolean, optional, default=no change
 
 ### Example
+```yaml
     id: update-client
     author: klg71
     changes:
@@ -90,6 +97,7 @@ Update a client
         redirectUris: 
             - http://localhost:8080
             - https://www.example.com
+```
 
 ## assignRoleToClient
 Assigns a realm- or client-role(if roleClientId is set) to a service account of a client.
@@ -101,6 +109,7 @@ Assigns a realm- or client-role(if roleClientId is set) to a service account of 
 - roleClientId: String, optional, default = realmRole
 
 ### Example
+```yaml
     id: add-client-roles
     author: klg71
     realm: integ-test
@@ -115,6 +124,7 @@ Assigns a realm- or client-role(if roleClientId is set) to a service account of 
           clientId: testClientRoles
           role: query-users
           roleClientId: realm-management
+```
 
 ## addRoleScopeMapping
 Adds a realm- or client-role(if roleClientId is set) to the cope mappings of a client.
@@ -128,6 +138,7 @@ See https://www.keycloak.org/docs/latest/server_admin/#_role_scope_mappings
 - roleClientId: String, optional, default = realmRole
 
 ### Example
+```yaml
     id: add-client-role-mapping
     author: klg71
     realm: integ-test
@@ -146,6 +157,7 @@ See https://www.keycloak.org/docs/latest/server_admin/#_role_scope_mappings
           clientId: testClientRoleScopeMappings
           role: query-users
           roleClientId: realm-management
+```
 
 ## addClientMapper
 adds a full configurable clientmapper, throws error if client or realm doesn't exist or mapper with same name already exists
@@ -161,6 +173,7 @@ adds a full configurable clientmapper, throws error if client or realm doesn't e
 - protocol: String, optional, default="openid-connect"
 
 ### Example:
+```yaml
     id: add-client-mappers
     author: klg71
     realm: integ-test
@@ -178,6 +191,7 @@ adds a full configurable clientmapper, throws error if client or realm doesn't e
             claim.name: customPropertyMapper
             jsonType.label: String
             user.attribute: UserModel.getEmail()
+```
 
 ## deleteClientMapper
 deletes a client mapper
@@ -188,6 +202,7 @@ deletes a client mapper
 - name: String, not optional
 
 ### Example:
+```yaml
     id: add-client-mappers
     author: klg71
     realm: integ-test
@@ -208,6 +223,7 @@ deletes a client mapper
       - deleteClientMapper:
           clientId: testMappers
           name: testPropertyMapper
+```
 
 ## addClientAudienceMapper
 adds a audience clientmapper, throws error if client or realm doesn't exist or mapper with same name already exists
@@ -222,6 +238,7 @@ adds a audience clientmapper, throws error if client or realm doesn't exist or m
 - customAudience: String, optional, default = ""
 
 ### Example:
+```yaml
     id: add-client-mappers
     author: klg71
     realm: integ-test
@@ -234,6 +251,7 @@ adds a audience clientmapper, throws error if client or realm doesn't exist or m
           addToIdToken: false
           clientAudience: testMappers
           customAudience: completlyCustom
+```
 
 ## addClientGroupMembershipMapper
 adds a group-membership clientmapper, throws error if client or realm doesn't exist or mapper with same name already exists
@@ -249,6 +267,7 @@ adds a group-membership clientmapper, throws error if client or realm doesn't ex
 - claimName: String?, optional, default = << name parameter>>
 
 ### Example:
+```yaml
     id: add-client-mappers
     author: klg71
     realm: integ-test
@@ -260,6 +279,7 @@ adds a group-membership clientmapper, throws error if client or realm doesn't ex
           name: groupMembership
           addToAccessToken: false
           claimName: groupClaim
+```
 
 ## addClientUserAttributeMapper
 adds a user-attribute clientmapper, throws error if client or realm doesn't exist or mapper with same name already exists
@@ -277,6 +297,7 @@ adds a user-attribute clientmapper, throws error if client or realm doesn't exis
 - aggregateAttributeValues: Boolean, optional, default = true
 
 ### Example:
+```yaml
     id: add-client-mappers
     author: klg71
     realm: integ-test
@@ -288,6 +309,7 @@ adds a user-attribute clientmapper, throws error if client or realm doesn't exis
           name: userAttribute
           userAttribute: testAttribute
           addToUserInfo: false
+```
 
 ## addClientUserRealmRoleMapper
 adds a user-realm-role clientmapper, throws error if client or realm doesn't exist or mapper with same name already exists
@@ -303,6 +325,7 @@ adds a user-realm-role clientmapper, throws error if client or realm doesn't exi
 - prefix: String, optional, default = ""
 
 ### Example:
+```yaml
     id: add-client-mappers
     author: klg71
     realm: integ-test
@@ -313,3 +336,4 @@ adds a user-realm-role clientmapper, throws error if client or realm doesn't exi
           clientId: testMappers
           name: userRealmRole
           prefix: rolePrefix
+```

--- a/docsbuild/content/migrations/group.md
+++ b/docsbuild/content/migrations/group.md
@@ -16,12 +16,14 @@ Adds a new group to keycloak. Fails if the group already exists.
 - parent: String, default=empty
 
 ### Example
+```yaml
     id: test
     author: klg71
     changes:
     - addGroup:
         realm: master
         name: testGroup
+```
 
 ## deleteGroup
 Removes a group from keycloak. Fails if the group does not exist.
@@ -31,12 +33,14 @@ Removes a group from keycloak. Fails if the group does not exist.
 - name: String, not optional
 
 ### Example
+```yaml
     id: test
     author: klg71
     changes:
     - deleteGroup:
         realm: master
         name: testUser
+```
 
 ## updateGroup
 Updates a group from keycloak. Fails if the group does not exist.
@@ -49,6 +53,7 @@ Updates a group from keycloak. Fails if the group does not exist.
 - clientRoles: Map< String,List< String>>, optional, default=existing client roles, Key of the map is the clientId and the value is a List of roleNames to attach
 
 ### Example
+```yaml
     id: test
     author: klg71
     changes:
@@ -58,7 +63,8 @@ Updates a group from keycloak. Fails if the group does not exist.
           attributes:
             lkz:
               - "1234"
-              
+```
+
 ## assignRoleToGroup
 Assigns a role to a group in keycloak. Fails if the group or the role does not exist.
 
@@ -69,6 +75,7 @@ Assigns a role to a group in keycloak. Fails if the group or the role does not e
 - clientId: String, optional, default=realmRole
 
 ### Example
+```yaml
     id: test
     author: klg71
     changes:
@@ -76,7 +83,8 @@ Assigns a role to a group in keycloak. Fails if the group or the role does not e
           realm: integ-test
           role: parent
           group: test3
-          
+```
+
 ## revokeRoleFromGroup
 Revokes a role from a group in keycloak. Fails if the group or the role does not exist or the role is not assigned to the group.
 
@@ -87,6 +95,7 @@ Revokes a role from a group in keycloak. Fails if the group or the role does not
 - clientId: String, optional, default=realmRole
 
 ### Example
+```yaml
     id: test
     author: klg71
     changes:
@@ -94,3 +103,4 @@ Revokes a role from a group in keycloak. Fails if the group or the role does not
           realm: integ-test
           group: parent
           role: test3
+```

--- a/docsbuild/content/migrations/realm.md
+++ b/docsbuild/content/migrations/realm.md
@@ -16,12 +16,14 @@ adds a Realm, throws error if realm with that id already exists
 - id: String, optional, default=name
 
 ### Example
+```yaml
     id: add-realm
     author: klg71
     changes:
       - addRealm:
           name: integ-test
-          
+```
+
 ## deleteRealm
 deletes a Realm, throws error if realm with that id does not exists
 
@@ -29,12 +31,14 @@ deletes a Realm, throws error if realm with that id does not exists
 - id: String, not optional
 
 ### Example
+```yaml
     id: add-realm
     author: klg71
     changes:
       - deleteRealm:
           id: integ-test
-          
+```
+
 ## updateRealm
 updates a Realm, throws error if realm with that id does not exists
 
@@ -147,9 +151,11 @@ updates a Realm, throws error if realm with that id does not exists
 - loginTheme:String, optional
 
 ### Example
+```yaml
     id: update-realm
     author: klg71
     changes:
       - updateRealm:
           id: integ-test
           displayName: UpdatedRealm
+```

--- a/docsbuild/content/migrations/role.md
+++ b/docsbuild/content/migrations/role.md
@@ -25,6 +25,7 @@ Add a role to keycloak, fails if the role already exists
 - clientId: String, optional
 
 ### Example
+```yaml
     id: add-role
     author: klg71
     changes:
@@ -35,6 +36,8 @@ Add a role to keycloak, fails if the role already exists
           role:
           - value1
           - value2
+```
+
 ## deleteRole
 Delete a role from keycloak, fails if the role does not exist
 ### Parameters
@@ -42,6 +45,7 @@ Delete a role from keycloak, fails if the role does not exist
 - name: String, not optional,
 - clientId: String, optional, default=realmRole
 ### Example
+```yaml
     id: delete-role
     author: klg71
     changes:
@@ -49,3 +53,4 @@ Delete a role from keycloak, fails if the role does not exist
         realm: master
         name: test4
         clientId: test
+```

--- a/docsbuild/content/migrations/role.md
+++ b/docsbuild/content/migrations/role.md
@@ -9,7 +9,7 @@ permalink: /migrations/role/
 All migrations referring to the role resource.
 ## addRole
 Add a role to keycloak, fails if the role already exists
-### Parameter
+### Parameters
 - realm: String, optional
 - name: String, not optional,
 - clientId: String, optional, default=realmRole,
@@ -37,7 +37,7 @@ Add a role to keycloak, fails if the role already exists
           - value2
 ## deleteRole
 Delete a role from keycloak, fails if the role does not exist
-### Parameter
+### Parameters
 - realm: String, optional
 - name: String, not optional,
 - clientId: String, optional, default=realmRole

--- a/docsbuild/content/migrations/scopes.md
+++ b/docsbuild/content/migrations/scopes.md
@@ -103,6 +103,7 @@ adds a full configurable client scope mapper, throws error if client or realm do
 - protocol: String, optional, default="openid-connect"
 
 ### Example:
+```yaml
     id: add-client-scope-mappers
     author: klg71
     realm: integ-test
@@ -120,7 +121,7 @@ adds a full configurable client scope mapper, throws error if client or realm do
             claim.name: customPropertyMapper
             jsonType.label: String
             user.attribute: UserModel.getEmail()
-
+```
 ## deleteClientScopeMapper
 deletes a client scope mapper
 
@@ -130,6 +131,7 @@ deletes a client scope mapper
 - name: String, not optional
 
 ### Example:
+```yaml
     id: add-client-scope-mappers
     author: klg71
     realm: integ-test
@@ -150,6 +152,7 @@ deletes a client scope mapper
       - deleteClientScopeMapper:
           clientScopeName: testMappers
           name: testPropertyMapper
+```
 
 ## addClientScopeAudienceMapper
 adds an audience client scope mapper, throws error if client or realm doesn't exist or mapper with same name already exists
@@ -164,6 +167,7 @@ adds an audience client scope mapper, throws error if client or realm doesn't ex
 - customAudience: String, optional, default = ""
 
 ### Example:
+```yaml
     id: add-client-scope-mappers
     author: klg71
     realm: integ-test
@@ -176,6 +180,7 @@ adds an audience client scope mapper, throws error if client or realm doesn't ex
           addToIdToken: false
           clientAudience: testMappers
           customAudience: completlyCustom
+```
 
 ## addClientScopeGroupMembershipMapper
 adds a group-membership client scope mapper, throws error if client or realm doesn't exist or mapper with same name already exists
@@ -191,6 +196,7 @@ adds a group-membership client scope mapper, throws error if client or realm doe
 - claimName: String?, optional, default = << name parameter>>
 
 ### Example:
+```yaml
     id: add-client-scope-mappers
     author: klg71
     realm: integ-test
@@ -202,6 +208,7 @@ adds a group-membership client scope mapper, throws error if client or realm doe
           name: groupMembership
           addToAccessToken: false
           claimName: groupClaim
+```
 
 ## addClientScopeUserAttributeMapper
 adds a user-attribute client scope mapper, throws error if client or realm doesn't exist or mapper with same name already exists
@@ -219,6 +226,7 @@ adds a user-attribute client scope mapper, throws error if client or realm doesn
 - aggregateAttributeValues: Boolean, optional, default = true
 
 ### Example:
+```yaml
     id: add-client-scope-mappers
     author: klg71
     realm: integ-test
@@ -230,6 +238,7 @@ adds a user-attribute client scope mapper, throws error if client or realm doesn
           name: userAttribute
           userAttribute: testAttribute
           addToUserInfo: false
+```
 
 ## addClientScopeUserRealmRoleMapper
 adds a user-realm-role client scope mapper, throws error if client or realm doesn't exist or mapper with same name already exists
@@ -245,6 +254,7 @@ adds a user-realm-role client scope mapper, throws error if client or realm does
 - prefix: String, optional, default = ""
 
 ### Example:
+```yaml
     id: add-client-scope-mappers
     author: klg71
     realm: integ-test
@@ -255,3 +265,4 @@ adds a user-realm-role client scope mapper, throws error if client or realm does
           clientScopeName: testMappers
           name: userRealmRole
           prefix: rolePrefix
+```

--- a/docsbuild/content/migrations/scopes.md
+++ b/docsbuild/content/migrations/scopes.md
@@ -10,7 +10,7 @@ All migrations referring to the ClientScope resource.
 
 ## addClientScope
 Adds a clientScope to keycloak, fails if a clientScope with that name already exists
-### Parameter
+### Parameters
 - realm: String, optional
 - name: String, not optional
 - description: String, optional, default = null
@@ -68,7 +68,7 @@ changes:
 
 ## assignDefaultClientScope
 Assigns a default clientScope to a client, fails if the client or scope doesn't exist.
-### Parameter
+### Parameters
 - realm: String, optional
 - clientScopeName: String
 - clientId: String

--- a/docsbuild/content/migrations/user.md
+++ b/docsbuild/content/migrations/user.md
@@ -28,6 +28,7 @@ ClientRole Parameters:
 - role: Rolename, String, not optional
 
 ### Example
+```yaml
     id: test
     author: klg71
     changes:
@@ -48,7 +49,7 @@ ClientRole Parameters:
           clientRoles:
             - client: testClient
               role: testClientRole
-
+```
 ## deleteUser
 
 Removes a user from keycloak. Fails if a user with that name does not exists.
@@ -58,14 +59,15 @@ Removes a user from keycloak. Fails if a user with that name does not exists.
 - name: String, not optional
 
 ### Example
-
+```yaml
     id: test
     author: klg71
     changes:
     - deleteUser:
         realm: master
         name: test
-        
+```
+
 ## updateUser
 
 Updates an exiting user in keycloak. Fails if no user with given name exists.
@@ -96,7 +98,7 @@ Updates an exiting user in keycloak. Fails if no user with given name exists.
     - config1: Map<String, String>, optional, default = emptyMap() (See keycloak documentation)
     
 ### Example
-
+```yaml
     id: test
     author: klg71
     changes:
@@ -105,7 +107,7 @@ Updates an exiting user in keycloak. Fails if no user with given name exists.
         name: test
         enabled: false
         lastName: Lukas
-        
+```        
 ### Example to update Password
 
 > If you don't want to hash and generate the salt by youself you can use the [updateUserPassword](#updateuserpassword) method listed below.
@@ -113,7 +115,7 @@ Updates an exiting user in keycloak. Fails if no user with given name exists.
 > This method gives more control over the credential entry in keycloak including hashIterations, algorithms used, digits and additional configs.
 >
 > Updating the credential can not be rolled back!
-
+```yaml
     id: update-password
     author: klg71
     changes:
@@ -123,7 +125,7 @@ Updates an exiting user in keycloak. Fails if no user with given name exists.
           credentials:
             - hashedSaltedValue: 1tWf95Drz6t8/9kKE3tiJXPywCzG/C0KDnmCIFXEDdFQMPB6iVWWxjLO9HJI3YwTfWZa78N+hcmYHcT1tkavcA==
               salt: dGVzdB==
-              
+```
 #### Script to generate salt and hash:
 
 ```kotlin
@@ -176,6 +178,7 @@ The password is hashed with 27500 hash_iterations and a key_byte_length of 64 by
 - salt: String, optional, default = Random 15 letter alphanumeric String
 
 ### Example
+```yaml
     id: test
     author: klg71
     realm: integ-test
@@ -185,6 +188,7 @@ The password is hashed with 27500 hash_iterations and a key_byte_length of 64 by
       - updateUserPassword:
           name: testPasswordUser
           password: "testPassword"
+```
 
 ## addUserAttribute
 Adds an attribute to an existing user. Throws an error if the user does not exist.
@@ -198,6 +202,7 @@ User attributes can't be set deterministic with the updateUser action.
 - override: Boolean, default=false
 
 ### Example
+```yaml
     id: test
     author: klg71
     changes:
@@ -208,7 +213,7 @@ User attributes can't be set deterministic with the updateUser action.
         attributeValues:
         - value1
         - value2
-
+```
 ## deleteUserAttribute
 Deletes an attribute to an existing user. Throws an error if the user does not exist.
 ### Parameters
@@ -218,6 +223,7 @@ Deletes an attribute to an existing user. Throws an error if the user does not e
 - failOnMissing: Boolean, default=true
 
 ### Example
+```yaml
     id: test
     author: klg71
     changes:
@@ -225,7 +231,7 @@ Deletes an attribute to an existing user. Throws an error if the user does not e
         realm: master
         name: test
         attributeName: test1
-
+```
 ## assignRole
 Assigns a role to the given user. Fails if the user or the role doesn't exist.
 ### Parameters
@@ -234,6 +240,7 @@ Assigns a role to the given user. Fails if the user or the role doesn't exist.
 - role: String, not optional
 
 ### Example
+```yaml
     id: test
     author: klg71
     changes:
@@ -241,6 +248,7 @@ Assigns a role to the given user. Fails if the user or the role doesn't exist.
         realm: master
         user: testUser
         role: testRole
+```
 
 ## revokeRole
 Revokes a role from the given user. Fails if the user or the role doesn't exist or the user does not have the role assigned.
@@ -251,6 +259,7 @@ Revokes a role from the given user. Fails if the user or the role doesn't exist 
 - role: String, not optional
 
 ### Example
+```yaml
     id: test
     author: klg71
     changes:
@@ -258,7 +267,8 @@ Revokes a role from the given user. Fails if the user or the role doesn't exist 
         realm: master
         user: testUser
         role: testRole
-        
+```
+
 ## assignGroup
 Assigns a group to the given user. Fails if the user or the group doesn't exist.
 ### Parameters
@@ -267,6 +277,7 @@ Assigns a group to the given user. Fails if the user or the group doesn't exist.
 - group: String, not optional
 
 ### Example
+```yaml
     id: test
     author: klg71
     changes:
@@ -274,7 +285,7 @@ Assigns a group to the given user. Fails if the user or the group doesn't exist.
         realm: master
         user: testUser
         group: testGroup
-        
+```
 ## revokeGroup
 Revokes a group from the given user. Fails if the user or the group doesn't exist or the user doesnt have the group assigned .
 ### Parameters
@@ -283,6 +294,7 @@ Revokes a group from the given user. Fails if the user or the group doesn't exis
 - group: String, not optional
 
 ### Example
+```yaml
     id: test
     author: klg71
     changes:
@@ -290,3 +302,4 @@ Revokes a group from the given user. Fails if the user or the group doesn't exis
         realm: master
         user: testUser
         group: testGroup
+```

--- a/docsbuild/content/migrations/userfederation.md
+++ b/docsbuild/content/migrations/userfederation.md
@@ -70,6 +70,7 @@ or if a mapper with this name already exists in this ad
 - writeOnly: Boolean, optional, default = false
                 
 ### Example
+```yaml
     id: add-ad-ldap-full-name-mapper
     author: klg71
     realm: integ-test
@@ -78,7 +79,7 @@ or if a mapper with this name already exists in this ad
           name: testFullNamemapper
           adName: testLdap
           ldapFullNameAttribute: fullName
-          
+```    
 ## AddAdLdapGroupMapper
 Adds a group mapper to an active directory ldap, throws an error if the ad doesn't exists
 or if a mapper with this name already exists in this ad
@@ -103,6 +104,7 @@ or if a mapper with this name already exists in this ad
 - dropNonExistingGroupsDuringSync: Boolean, optional, default = false
                 
 ### Example
+```yaml
     id: add-ad-ldap-group-mapper
     author: klg71
     realm: integ-test
@@ -111,7 +113,8 @@ or if a mapper with this name already exists in this ad
           name: testGroupMapper
           adName: testLdap
           groupsDn: groupsDn
-          
+```
+
 ## AddAdLdapHardcodedRoleMapper
 Adds a hardcoded role mapper to an active directory ldap, throws an error if the ad doesn't exists
 or if a mapper with this name already exists in this ad. If the given role doesn't exists this command throws an exception.
@@ -123,6 +126,7 @@ or if a mapper with this name already exists in this ad. If the given role doesn
 - role: String, not optional
                 
 ### Example
+```yaml
     id: add-ad-ldap-hardcoded-role-mapper
     author: klg71
     realm: integ-test
@@ -133,7 +137,8 @@ or if a mapper with this name already exists in this ad. If the given role doesn
           name: testHardcodedRoleMapper
           adName: testLdap
           role: testMapperRole
-          
+```
+
 ## AddAdLdapUserControlMapperMapper
 Adds a user account control mapper to an active directory ldap, throws an error if the ad doesn't exists
 or if a mapper with this name already exists in this ad. 
@@ -144,6 +149,7 @@ or if a mapper with this name already exists in this ad.
 - adName: String, not optional
                 
 ### Example
+```yaml
     id: add-ad-ldap-user-account-control-mapper
     author: klg71
     realm: integ-test
@@ -151,7 +157,7 @@ or if a mapper with this name already exists in this ad.
       - addAdLdapUserAccountControlMapper:
           name: testUserAccountControl
           adName: testLdap
-          
+```          
 ## AddAdLdapUserAttributeMapperMapper
 Adds a user account attribute mapper to an active directory ldap, throws an error if the ad doesn't exists
 or if a mapper with this name already exists in this ad. 
@@ -167,6 +173,7 @@ or if a mapper with this name already exists in this ad.
 - isMandatoryInLdap: Boolean, optional, default = false
                 
 ### Example
+```yaml
     id: add-ad-ldap-user-attribute-mapper
     author: klg71
     realm: integ-test
@@ -176,7 +183,8 @@ or if a mapper with this name already exists in this ad.
           adName: testLdap
           userModelAttribute: userModelAttribute
           ldapAttribute: ldapAttribute
-          
+```
+
 ## AddAdLdapMapperMapper
 Adds a custom mapper to an active directory ldap, throws an error if the ad doesn't exists
 or if a mapper with this name already exists in this ad. 
@@ -193,6 +201,7 @@ or if a mapper with this name already exists in this ad.
 - config: Map<String,String>, not optional
                 
 ### Example
+```yaml
     id: add-ad-ldap-user-attribute-mapper
     author: klg71
     realm: integ-test
@@ -212,7 +221,8 @@ or if a mapper with this name already exists in this ad.
               roles.dn: "rolesDn"
               use.realm.roles.mapping: "true"
               user.roles.retrieve.strategy: "LOAD_ROLES_BY_MEMBERSHIP_ATTRIBUTE"
-          
+```
+
 ## AddUserFederation
 Adds a user federation to the realm
 
@@ -243,9 +253,11 @@ Deletes an userFederation from the realm, throws an exception if it doesn't exis
 - name: String, not optional
                 
 ### Example
+```yaml
     id: delete-ad-ldap
     author: klg71
     changes:
       - deleteUserFederation:
           realm: integ-test
           name: testLdap
+```

--- a/docsbuild/content/quickstart/groovy.md
+++ b/docsbuild/content/quickstart/groovy.md
@@ -18,7 +18,8 @@ plugins {
 repositories { 
   jcenter()
 }
-
+```
+```groovy
 task keycloakMigrateLocal(type: KeycloakMigrationTask) {
       group = "keycloak"
       description = "Migrate the keycloak instance"


### PR DESCRIPTION
Changed `Parameter` to `Parameters`, to match the rest of the docs.  Also I've put all (missing) examples in a yaml container.