### PR TITLE
fix(group): allow role revocation for client roles

### DIFF
--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/group/RevokeRoleFromGroupAction.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/group/RevokeRoleFromGroupAction.kt
@@ -8,6 +8,7 @@ import de.klg71.keycloakmigration.keycloakapi.clientRoleByName
 import de.klg71.keycloakmigration.keycloakapi.clientUUID
 import de.klg71.keycloakmigration.keycloakapi.existsGroup
 import de.klg71.keycloakmigration.keycloakapi.existsRole
+import de.klg71.keycloakmigration.keycloakapi.existsClientRole
 import de.klg71.keycloakmigration.keycloakapi.groupUUID
 import java.util.Objects.isNull
 

--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/group/RevokeRoleFromGroupAction.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/group/RevokeRoleFromGroupAction.kt
@@ -28,8 +28,7 @@ class RevokeRoleFromGroupAction(
             }
         } else {
             if (!client.existsClientRole(role, realm(), clientId)) {
-                throw MigrationException(
-                        "Role with name: $role in client: $clientId does not exist in realm: ${realm()}!")
+                throw MigrationException("Role with name: $role in client: $clientId does not exist in realm: ${realm()}!")
             }
         }
 

--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/group/RevokeRoleFromGroupAction.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/group/RevokeRoleFromGroupAction.kt
@@ -18,16 +18,17 @@ class RevokeRoleFromGroupAction(
         private val clientId: String? = null) : Action(realm) {
 
     override fun execute() {
-        if (!client.existsGroup(group, realm())) {
+       if (!client.existsGroup(group, realm())) {
             throw MigrationException("Group with name: $group does not exist in realm: ${realm()}!")
         }
-        if (!client.existsRole(role, realm())) {
-            throw MigrationException("Role with name: $role does not exist in realm: ${realm()}!")
-        }
-
-        client.groupRoles(realm(), client.groupUUID(group, realm())).run {
-            if (!map { it.name }.contains(role)) {
-                throw MigrationException("Group with name: $group in realm: ${realm()} does not have role: $role!")
+        if (clientId == null) {
+            if (!client.existsRole(role, realm())) {
+                throw MigrationException("Role with name: $role does not exist in realm: ${realm()}!")
+            }
+        } else {
+            if (!client.existsClientRole(role, realm(), clientId)) {
+                throw MigrationException(
+                        "Role with name: $role in client: $clientId does not exist in realm: ${realm()}!")
             }
         }
 

--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/group/RevokeRoleFromGroupAction.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/group/RevokeRoleFromGroupAction.kt
@@ -33,6 +33,12 @@ class RevokeRoleFromGroupAction(
             }
         }
 
+        client.groupRoles(realm(), client.groupUUID(group, realm())).run {
+            if (!map { it.name }.contains(role)) {
+                throw MigrationException("Group with name: $group in realm: ${realm()} does not have role: $role!")
+            }
+        }
+
         findRole().run {
             assignRole()
         }.let {

--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/group/RevokeRoleFromGroupAction.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/group/RevokeRoleFromGroupAction.kt
@@ -18,9 +18,10 @@ class RevokeRoleFromGroupAction(
         private val clientId: String? = null) : Action(realm) {
 
     override fun execute() {
-       if (!client.existsGroup(group, realm())) {
+        if (!client.existsGroup(group, realm())) {
             throw MigrationException("Group with name: $group does not exist in realm: ${realm()}!")
         }
+        
         if (clientId == null) {
             if (!client.existsRole(role, realm())) {
                 throw MigrationException("Role with name: $role does not exist in realm: ${realm()}!")

--- a/src/test/kotlin/de/klg71/keycloakmigration/changeControl/actions/group/RevokeRoleFromGroupIntegTest.kt
+++ b/src/test/kotlin/de/klg71/keycloakmigration/changeControl/actions/group/RevokeRoleFromGroupIntegTest.kt
@@ -2,6 +2,8 @@ package de.klg71.keycloakmigration.changeControl.actions.group
 
 import de.klg71.keycloakmigration.AbstractIntegrationTest
 import de.klg71.keycloakmigration.changeControl.actions.MigrationException
+import de.klg71.keycloakmigration.changeControl.actions.client.AddSimpleClientAction
+import de.klg71.keycloakmigration.changeControl.actions.client.UpdateClientAction
 import de.klg71.keycloakmigration.changeControl.actions.role.AddRoleAction
 import de.klg71.keycloakmigration.keycloakapi.KeycloakClient
 import de.klg71.keycloakmigration.keycloakapi.groupByName
@@ -15,46 +17,61 @@ import java.util.UUID
 class RevokeRoleFromGroupIntegTest : AbstractIntegrationTest() {
 
     private val client by inject<KeycloakClient>()
+    private val clientId = "clientId"
+    private val role = "testRole"
+    private val group = "testIntegration"
+
 
     @Test
     fun testRevokeRole() {
-        AddGroupAction(testRealm, "testIntegration").executeIt()
-        AddRoleAction(testRealm, "testRole").executeIt()
-        AssignRoleToGroupAction(testRealm, "testRole", "testIntegration").executeIt()
-        RevokeRoleFromGroupAction(testRealm, "testRole", "testIntegration").executeIt()
+        AddGroupAction(testRealm, group).executeIt()
+        AddRoleAction(testRealm, role).executeIt()
+        AssignRoleToGroupAction(testRealm, role, group).executeIt()
+        RevokeRoleFromGroupAction(testRealm, role, group).executeIt()
 
-        val testRole = RoleListItem(UUID.randomUUID(), "testRole", null, false, false, testRealm)
+        val role = RoleListItem(UUID.randomUUID(), role, null, false, false, testRealm)
 
-        client.groupRoles(testRealm, client.groupByName("testIntegration", testRealm).id).let {
-            assertThat(it).usingElementComparatorOnFields("name", "containerId").doesNotContain(testRole)
+        client.groupRoles(testRealm, client.groupByName(group, testRealm).id).let {
+            assertThat(it).usingElementComparatorOnFields("name", "containerId").doesNotContain(role)
         }
     }
 
     @Test
-    fun testRevokeRole_userNotExisting() {
-        AddRoleAction(testRealm, "testRole").executeIt()
+    fun testRevokeRole_groupNotExisting() {
+        AddRoleAction(testRealm, role).executeIt()
         assertThatThrownBy {
-            RevokeRoleFromGroupAction(testRealm, "testRole", "testIntegration").executeIt()
+            RevokeRoleFromGroupAction(testRealm, role, group).executeIt()
         }.isInstanceOf(MigrationException::class.java)
-            .hasMessage("Group with name: testIntegration does not exist in realm: ${testRealm}!")
+            .hasMessage("Group with name: $group does not exist in realm: $testRealm!")
     }
 
     @Test
-    fun testAssignRole_roleNotExisting() {
-        AddGroupAction(testRealm, "testIntegration").executeIt()
+    fun testAssignRole_realmRoleNotExisting() {
+        AddGroupAction(testRealm, group).executeIt()
         assertThatThrownBy {
-            RevokeRoleFromGroupAction(testRealm, "testRole", "testIntegration").executeIt()
+            RevokeRoleFromGroupAction(testRealm, role, group).executeIt()
         }.isInstanceOf(MigrationException::class.java)
-            .hasMessage("Role with name: testRole does not exist in realm: ${testRealm}!")
+            .hasMessage("Role with name: $role does not exist in realm: $testRealm!")
     }
+
+    @Test
+    fun testAssignRole_clientRoleNotExisting() {
+        AddSimpleClientAction(testRealm, clientId).executeIt()
+        AddGroupAction(testRealm, group).executeIt()
+        assertThatThrownBy {
+            RevokeRoleFromGroupAction(testRealm, role, group, clientId).executeIt()
+        }.isInstanceOf(MigrationException::class.java)
+            .hasMessage("Role with name: $role in client: $clientId does not exist in realm: $testRealm!")
+    }
+
 
     @Test
     fun testAssignRole_roleNotAssigned() {
-        AddGroupAction(testRealm, "testIntegration").executeIt()
-        AddRoleAction(testRealm, "testRole").executeIt()
+        AddGroupAction(testRealm, group).executeIt()
+        AddRoleAction(testRealm, role).executeIt()
         assertThatThrownBy {
-            RevokeRoleFromGroupAction(testRealm, "testRole", "testIntegration").executeIt()
+            RevokeRoleFromGroupAction(testRealm, role, group).executeIt()
         }.isInstanceOf(MigrationException::class.java)
-            .hasMessage("Group with name: testIntegration in realm: ${testRealm} does not have role: testRole!")
+            .hasMessage("Group with name: $group in realm: $testRealm does not have role: $role!")
     }
 }


### PR DESCRIPTION
Fixes a bug to allow revoking ClientRoles from groups.

Right now the application throws an error right away because it's just checking for realm roles. 