### PR TITLE
fix(identityProvider): make displayName optional

### DIFF
--- a/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/model/AddIdentityProvider.kt
+++ b/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/model/AddIdentityProvider.kt
@@ -3,7 +3,7 @@ package de.klg71.keycloakmigration.keycloakapi.model
 data class AddIdentityProvider(
     val providerId: String,
     val alias: String,
-    val displayName: String,
+    val displayName: String? = null,
     val enabled: Boolean,
     val config: Map<String, String>,
     val trustEmail: Boolean,

--- a/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/model/IdentityProvider.kt
+++ b/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/model/IdentityProvider.kt
@@ -6,14 +6,14 @@ data class IdentityProvider(
     val providerId: String,
     val internalId: UUID,
     val alias: String,
-    val displayName: String,
+    val displayName: String? = null,
     val enabled: Boolean,
     val config: Map<String, String>,
     val trustEmail: Boolean,
     val storeToken: Boolean,
     val linkOnly: Boolean,
     val firstBrokerLoginFlowAlias: String="",
-    val postBrokerLoginFlowAlias: String="",
+val postBrokerLoginFlowAlias: String="",
     val updateProfileFirstLoginMode: String
 )
 

--- a/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/model/IdentityProvider.kt
+++ b/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/model/IdentityProvider.kt
@@ -13,7 +13,7 @@ data class IdentityProvider(
     val storeToken: Boolean,
     val linkOnly: Boolean,
     val firstBrokerLoginFlowAlias: String="",
-val postBrokerLoginFlowAlias: String="",
+    val postBrokerLoginFlowAlias: String="",
     val updateProfileFirstLoginMode: String
 )
 

--- a/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/model/UpdateIdentityProvider.kt
+++ b/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/model/UpdateIdentityProvider.kt
@@ -6,7 +6,7 @@ data class UpdateIdentityProvider(
     val internalId: UUID,
     val providerId: String,
     val alias: String,
-    val displayName: String,
+    val displayName: String? = null,
     val enabled: Boolean,
     val config: Map<String, String>,
     val trustEmail: Boolean,


### PR DESCRIPTION
Hey there! 

This PR fixes a bug where identityProviders without a displayName can't be updated (and probably not deleted). 

The field is optional by keycloak (e.g. for so called "social identity providers" like LinkedIn) and should therefore also be optional internally.

**Reproduction:**

1. Create an identityProvider without displayName field (e.g. LinkedIn).
2. Update the identityProvider:

```yaml
  - updateIdentityProvider:
      alias: google
      config:
        clientId: test
        clientSecret: test
```

Results in: 

`Exception in thread "main" feign.FeignException: Instantiation of [simple type, class de.klg71.keycloakmigration.keycloakapi.model.IdentityProvider] value failed for JSON property displayName due to missing (therefore NULL) value for creator parameter displayName which is a non-nullable type`