### PR TITLE
koin upgrade to 3.2.2 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.2")
-    implementation("io.insert-koin:koin-core:3.1.4")
+    implementation("io.insert-koin:koin-core:3.2.2")
     implementation("commons-codec:commons-codec:1.11")
     implementation("com.xenomachina:kotlin-argparser:2.0.7")
 
@@ -44,7 +44,7 @@ dependencies {
     testImplementation("io.mockk:mockk:1.12.1")
 
     testImplementation("org.assertj:assertj-core:3.11.1")
-    testImplementation("io.insert-koin:koin-test:3.1.4")
+    testImplementation("io.insert-koin:koin-test:3.2.2")
     testImplementation("org.assertj:assertj-core:3.11.1")
     testImplementation("com.github.tomakehurst:wiremock-jre8:2.27.0")
 }

--- a/keycloakapi/build.gradle.kts
+++ b/keycloakapi/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.2")
-    implementation("io.insert-koin:koin-core:3.1.3")
+    implementation("io.insert-koin:koin-core:3.2.2")
     implementation("commons-codec:commons-codec:1.11")
     implementation("com.xenomachina:kotlin-argparser:2.0.7")
 
@@ -38,7 +38,7 @@ dependencies {
     testImplementation(kotlin("test-junit"))
     testImplementation("io.mockk:mockk:1.9")
     testImplementation("org.assertj:assertj-core:3.11.1")
-    testImplementation("io.insert-koin:koin-test:3.1.3")
+    testImplementation("io.insert-koin:koin-test:3.2.2")
     testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0")
     testImplementation("org.assertj:assertj-core:3.11.1")
 }


### PR DESCRIPTION
With the current version, I get the following error message when I upgrade Gradle from 7.4.2 to 7.5.1 and then want to use the keycloak migration:

```
Caused by: java.lang.NoSuchMethodError: 'double kotlin.time.Duration.toDouble-impl(long, java.util.concurrent.TimeUnit)'
        at org.koin.core.time.MeasureKt.measureDuration(Measure.kt:32)
        at org.koin.core.KoinApplication.modules(KoinApplication.kt:59)
        at org.koin.core.KoinApplication.modules(KoinApplication.kt:42)
        at de.klg71.keycloakmigration.MainKt$migrate$1$1.invoke(Main.kt:68)
        at de.klg71.keycloakmigration.MainKt$migrate$1$1.invoke(Main.kt:66)
        at org.koin.core.context.GlobalContext.startKoin(GlobalContext.kt:64)
        at org.koin.core.context.DefaultContextExtKt.startKoin(DefaultContextExt.kt:31)
        at de.klg71.keycloakmigration.MainKt.migrate(Main.kt:66)
        at de.klg71.keycloakmigrationplugin.KeycloakMigrationTask.migrate(KeycloakMigrationTask.kt:55)
....
```

I checked out the plugin locally, pulled up the version and then tried it with that. The error then does not occur. 