### PR TITLE
Feature/add delete identity provider mapper action

### DIFF
--- a/docsbuild/content/migrations/identityprovider.md
+++ b/docsbuild/content/migrations/identityprovider.md
@@ -466,3 +466,23 @@ changes:
       attributeValue: sourceRoleA
       role: targetRoleB
 ```    
+
+## DeleteIdentityProviderMapper
+Deletes a mapper from an identity provider.
+
+### Parameters
+- realm: String, optional
+- name: String, not optional
+- identityProviderAlias: String, not optional
+
+### Example
+```yaml
+id: delete-identity-provider-mapper
+author: klg71
+realm: integ-test
+changes:
+  - deleteIdentityProviderMapper:
+      identityProviderAlias: idpAlias
+      name: surnameMapper
+```    
+

--- a/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/model/AddIdentityProviderMapper.kt
+++ b/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/model/AddIdentityProviderMapper.kt
@@ -5,7 +5,17 @@ data class AddIdentityProviderMapper(
     val identityProviderAlias: String,
     val identityProviderMapper: String,
     val name: String
-)
+) {
+    companion object {
+        @JvmStatic
+        fun from(mapper: IdentityProviderMapper) = AddIdentityProviderMapper(
+            mapper.config,
+            mapper.identityProviderAlias,
+            mapper.identityProviderMapper,
+            mapper.name
+        )
+    }
+}
 
 const val SAML_USER_ATTRIBUTE_IDP_MAPPER = "saml-user-attribute-idp-mapper"
 const val SAML_ROLE_IDP_MAPPER = "saml-role-idp-mapper"

--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/ActionFactory.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/ActionFactory.kt
@@ -53,6 +53,7 @@ import de.klg71.keycloakmigration.changeControl.actions.identityprovider.mapper.
 import de.klg71.keycloakmigration.changeControl.actions.identityprovider.mapper.AddSamlNameAttributeMapperAction
 import de.klg71.keycloakmigration.changeControl.actions.identityprovider.mapper.AddSamlRoleMapperAction
 import de.klg71.keycloakmigration.changeControl.actions.identityprovider.mapper.AddSamlSurnameAttributeMapperAction
+import de.klg71.keycloakmigration.changeControl.actions.identityprovider.mapper.DeleteIdentityProviderMapperAction
 import de.klg71.keycloakmigration.changeControl.actions.realm.AddRealmAction
 import de.klg71.keycloakmigration.changeControl.actions.realm.DeleteRealmAction
 import de.klg71.keycloakmigration.changeControl.actions.realm.UpdateRealmAction
@@ -188,6 +189,7 @@ class ActionFactory(private val objectMapper: ObjectMapper) {
             )
             "addSamlSurnameAttributeMapper" -> objectMapper.readValue<AddSamlSurnameAttributeMapperAction>(actionJson)
             "addSamlRoleMapper" -> objectMapper.readValue<AddSamlRoleMapperAction>(actionJson)
+            "deleteIdentityProviderMapper" -> objectMapper.readValue<DeleteIdentityProviderMapperAction>(actionJson)
 
             "addFlow" -> objectMapper.readValue<AddFlowAction>(actionJson)
             "deleteFlow" -> objectMapper.readValue<DeleteFlowAction>(actionJson)

--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/identityprovider/mapper/AddIdentityProviderMapperAction.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/identityprovider/mapper/AddIdentityProviderMapperAction.kt
@@ -9,10 +9,12 @@ import de.klg71.keycloakmigration.keycloakapi.identityProviderMapperExistsByName
 import de.klg71.keycloakmigration.keycloakapi.isSuccessful
 import de.klg71.keycloakmigration.keycloakapi.model.AddIdentityProviderMapper
 
-internal fun assertIdentityProviderMapperIsCreatable(client: KeycloakClient,
+internal fun assertIdentityProviderMapperIsCreatable(
+    client: KeycloakClient,
     name: String,
     identityProviderAlias: String,
-    realm: String) {
+    realm: String
+) {
     if (!client.identityProviderExistsByAlias(identityProviderAlias, realm)) {
         throw MigrationException("IdentityProvider with name: $identityProviderAlias does not exist in realm: $realm!")
     }
@@ -22,6 +24,17 @@ internal fun assertIdentityProviderMapperIsCreatable(client: KeycloakClient,
                     " $identityProviderAlias in realm: $realm!"
         )
     }
+}
+
+internal fun addIdentityProviderMapper(
+    client: KeycloakClient,
+    mapper: AddIdentityProviderMapper,
+    identityProviderAlias: String,
+    name: String,
+    realm: String
+) {
+    assertIdentityProviderMapperIsCreatable(client, name, identityProviderAlias, realm)
+    client.addIdentityProviderMapper(mapper, realm, identityProviderAlias)
 }
 
 internal class AddIdentityProviderMapperAction(
@@ -34,7 +47,11 @@ internal class AddIdentityProviderMapperAction(
 
     override fun execute() {
         assertIdentityProviderMapperIsCreatable(client, name, identityProviderAlias, realm())
-        client.addIdentityProviderMapper(addIdentityProviderMapper(), realm(), identityProviderAlias).apply {
+        client.addIdentityProviderMapper(
+            addIdentityProviderMapper(),
+            realm(),
+            identityProviderAlias
+        ).apply {
             if (!isSuccessful()) {
                 throw KeycloakApiException(this.body().asReader().readText())
             }

--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/identityprovider/mapper/AddIdentityProviderMapperAction.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/identityprovider/mapper/AddIdentityProviderMapperAction.kt
@@ -69,6 +69,6 @@ internal class AddIdentityProviderMapperAction(
         }
     }
 
-    override fun name() = "AddIdentityProviderMapper $name"
+    override fun name() = "AddIdentityProviderMapper $name to $identityProviderAlias"
 
 }

--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/identityprovider/mapper/AddSamlEmailAddressAttributeMapperAction.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/identityprovider/mapper/AddSamlEmailAddressAttributeMapperAction.kt
@@ -33,6 +33,6 @@ internal class AddSamlEmailAddressAttributeMapperAction(
         }
     }
 
-    override fun name() = "AddSamlEmailAddressAttributeMapper $name"
+    override fun name() = "AddSamlEmailAddressAttributeMapper $name to $identityProviderAlias"
 
 }

--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/identityprovider/mapper/AddSamlGivenNameAttributeMapperAction.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/identityprovider/mapper/AddSamlGivenNameAttributeMapperAction.kt
@@ -33,6 +33,6 @@ internal class AddSamlGivenNameAttributeMapperAction(
         }
     }
 
-    override fun name() = "AddSamlGivenNameAttributeMapper $name"
+    override fun name() = "AddSamlGivenNameAttributeMapper $name to $identityProviderAlias"
 
 }

--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/identityprovider/mapper/AddSamlMapperAction.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/identityprovider/mapper/AddSamlMapperAction.kt
@@ -50,6 +50,6 @@ internal class AddSamlMapperAction(
         }
     }
 
-    override fun name() = "AddSamlMapper $name"
+    override fun name() = "AddSamlMapper $name to $identityProviderAlias"
 
 }

--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/identityprovider/mapper/AddSamlNameAttributeMapperAction.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/identityprovider/mapper/AddSamlNameAttributeMapperAction.kt
@@ -33,6 +33,6 @@ internal class AddSamlNameAttributeMapperAction(
         }
     }
 
-    override fun name() = "AddSamlNameAttributeMapper $name"
+    override fun name() = "AddSamlNameAttributeMapper $name to $identityProviderAlias"
 
 }

--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/identityprovider/mapper/AddSamlRoleMapperAction.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/identityprovider/mapper/AddSamlRoleMapperAction.kt
@@ -34,6 +34,6 @@ internal class AddSamlRoleMapperAction(
         }
     }
 
-    override fun name() = "AddSamlRoleMapper $name"
+    override fun name() = "AddSamlRoleMapper $name to $identityProviderAlias"
 
 }

--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/identityprovider/mapper/AddSamlSurnameAttributeMapperAction.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/identityprovider/mapper/AddSamlSurnameAttributeMapperAction.kt
@@ -33,6 +33,6 @@ internal class AddSamlSurnameAttributeMapperAction(
         }
     }
 
-    override fun name() = "AddSamlSurnameAttributeMapper $name"
+    override fun name() = "AddSamlSurnameAttributeMapper $name to $identityProviderAlias"
 
 }

--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/identityprovider/mapper/DeleteIdentityProviderMapperAction.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/identityprovider/mapper/DeleteIdentityProviderMapperAction.kt
@@ -1,0 +1,30 @@
+package de.klg71.keycloakmigration.changeControl.actions.identityprovider.mapper
+
+import de.klg71.keycloakmigration.changeControl.actions.Action
+import de.klg71.keycloakmigration.keycloakapi.model.AddIdentityProviderMapper
+import de.klg71.keycloakmigration.keycloakapi.model.IdentityProviderMapper
+
+open class DeleteIdentityProviderMapperAction(
+    realm: String?,
+    protected val identityProviderAlias: String,
+    protected val name: String
+) : Action(realm) {
+
+    private var deletedMapper: IdentityProviderMapper? = null;
+
+    override fun execute() {
+        deletedMapper = client.identityProviderMappers(realm(), identityProviderAlias).firstOrNull { it.name == name }
+        deletedMapper?.let {
+            client.deleteIdentityProviderMapper(realm(), identityProviderAlias, it.id)
+        }
+    }
+
+    override fun undo() {
+        deletedMapper?.let {
+            addIdentityProviderMapper(client, AddIdentityProviderMapper.from(it), identityProviderAlias, name, realm())
+        }
+    }
+
+    override fun name() = "DeleteIdentityProviderMapper $name from $identityProviderAlias"
+
+}

--- a/src/test/kotlin/de/klg71/keycloakmigration/changeControl/actions/identityprovider/mapper/DeleteIdentityProviderMapperIntegTest.kt
+++ b/src/test/kotlin/de/klg71/keycloakmigration/changeControl/actions/identityprovider/mapper/DeleteIdentityProviderMapperIntegTest.kt
@@ -1,0 +1,124 @@
+package de.klg71.keycloakmigration.changeControl.actions.identityprovider.mapper
+
+import de.klg71.keycloakmigration.AbstractIntegrationTest
+import de.klg71.keycloakmigration.changeControl.actions.identityprovider.AddIdentityProviderAction
+import de.klg71.keycloakmigration.keycloakapi.KeycloakClient
+import de.klg71.keycloakmigration.keycloakapi.identityProviderByAlias
+import de.klg71.keycloakmigration.keycloakapi.identityProviderMapperByName
+import de.klg71.keycloakmigration.keycloakapi.identityProviderMapperExistsByName
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import org.koin.core.component.inject
+
+class DeleteIdentityProviderMapperIntegTest : AbstractIntegrationTest() {
+
+    val client by inject<KeycloakClient>()
+
+    @Test
+    fun testDeleteIdentityProviderMapper() {
+        val identityProviderConfig = mapOf(
+            "authorizationUrl" to "https://testUrl",
+            "tokenUrl" to "https://testUrl",
+            "issuer" to "issuer",
+            "defaultScopes" to "scope1,scope2"
+        )
+        val identityProviderAlias = "test"
+        AddIdentityProviderAction(
+            testRealm, identityProviderAlias, "saml", identityProviderConfig, displayName = "displayName", true, true,
+            true, true,
+            "first broker login", ""
+        ).executeIt()
+
+        val createdIdentityProvider = client.identityProviderByAlias(identityProviderAlias, testRealm)
+
+        val mapperName = "mapperName"
+        val mapperType = "saml-user-attribute-idp-mapper"
+        val attributeName = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
+        val userAttributeName = "attributeNameToBeMappedFrom"
+        val config = mapOf(
+            "user.attribute" to userAttributeName,
+            "attribute.name" to attributeName
+        )
+        AddIdentityProviderMapperAction(
+            testRealm,
+            config,
+            createdIdentityProvider.alias,
+            mapperType,
+            mapperName
+        ).executeIt()
+
+        val createdMapper = client.identityProviderMapperByName(identityProviderAlias, mapperName, testRealm)
+        Assertions.assertThat((createdMapper.config["user.attribute"] ?: error("test error"))).isEqualTo(
+            userAttributeName
+        )
+
+        DeleteIdentityProviderMapperAction(
+            testRealm,
+            createdMapper.identityProviderAlias,
+            createdMapper.name
+        ).executeIt()
+
+        Assertions.assertThat(
+            client.identityProviderMapperExistsByName(identityProviderAlias, mapperName, testRealm)
+        ).isFalse
+    }
+
+    @Test
+    fun testDeleteIdentityProviderMapper_Rollback() {
+        val identityProviderConfig = mapOf(
+            "authorizationUrl" to "https://testUrl",
+            "tokenUrl" to "https://testUrl",
+            "issuer" to "issuer",
+            "defaultScopes" to "scope1,scope2"
+        )
+        val identityProviderAlias = "test"
+        AddIdentityProviderAction(
+            testRealm, identityProviderAlias, "saml", identityProviderConfig, displayName = "displayName", true, true,
+            true, true,
+            "first broker login", ""
+        ).executeIt()
+
+        val createdIdentityProvider = client.identityProviderByAlias(identityProviderAlias, testRealm)
+
+        val mapperName = "mapperName"
+        val mapperType = "saml-user-attribute-idp-mapper"
+        val attributeName = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
+        val userAttributeName = "attributeNameToBeMappedFrom"
+        val config = mapOf(
+            "user.attribute" to userAttributeName,
+            "attribute.name" to attributeName
+        )
+        AddIdentityProviderMapperAction(
+            testRealm,
+            config,
+            createdIdentityProvider.alias,
+            mapperType,
+            mapperName
+        ).executeIt()
+
+        val createdMapper = client.identityProviderMapperByName(identityProviderAlias, mapperName, testRealm)
+        Assertions.assertThat((createdMapper.config["user.attribute"] ?: error("test error"))).isEqualTo(
+            userAttributeName
+        )
+
+        val action = DeleteIdentityProviderMapperAction(
+            testRealm,
+            createdMapper.identityProviderAlias,
+            createdMapper.name
+        )
+        action.executeIt()
+        Assertions.assertThat(
+            client.identityProviderMapperExistsByName(identityProviderAlias, mapperName, testRealm)
+        ).isFalse
+
+        action.undoIt()
+
+        val restoredMapper = client.identityProviderMapperByName(identityProviderAlias, mapperName, testRealm)
+
+        Assertions.assertThat(restoredMapper.identityProviderAlias).isEqualTo(createdMapper.identityProviderAlias)
+        Assertions.assertThat(restoredMapper.identityProviderMapper).isEqualTo(createdMapper.identityProviderMapper)
+        Assertions.assertThat(restoredMapper.name).isEqualTo(createdMapper.name)
+        Assertions.assertThat(restoredMapper.config).isEqualTo(createdMapper.config)
+
+    }
+}

--- a/src/test/resources/changesets/40_add_identity_provider_mappers.yml
+++ b/src/test/resources/changesets/40_add_identity_provider_mappers.yml
@@ -1,4 +1,4 @@
-id: add_identity_provider_mapper
+id: add_identity_provider_mappers
 author: istrauch
 realm: integ-test
 changes:
@@ -49,5 +49,3 @@ changes:
       name: testRoleMapper
       attributeValue: sourceRole
       role: targetRole
-  - deleteIdentityProvider:
-      alias: testAlias2

--- a/src/test/resources/changesets/41_delete_identity_provider_mappers.yml
+++ b/src/test/resources/changesets/41_delete_identity_provider_mappers.yml
@@ -1,0 +1,27 @@
+id: delete_identity_provider_mappers
+author: istrauch
+realm: integ-test
+changes:
+  - deleteIdentityProviderMapper:
+      identityProviderAlias: testAlias2
+      name: testGenericMapper
+  - deleteIdentityProviderMapper:
+      identityProviderAlias: testAlias2
+      name: testGenericMapperWithCheckOfUnderlyingIdpType
+  - deleteIdentityProviderMapper:
+      identityProviderAlias: testAlias2
+      name: testEmailMapper
+  - deleteIdentityProviderMapper:
+      identityProviderAlias: testAlias2
+      name: testNameMapper
+  - deleteIdentityProviderMapper:
+      identityProviderAlias: testAlias2
+      name: testGivenNameMapper
+  - deleteIdentityProviderMapper:
+      identityProviderAlias: testAlias2
+      name: testSurnameMapper
+  - deleteIdentityProviderMapper:
+      identityProviderAlias: testAlias2
+      name: testRoleMapper
+  - deleteIdentityProvider:
+      alias: testAlias2

--- a/src/test/resources/keycloak-changelog.yml
+++ b/src/test/resources/keycloak-changelog.yml
@@ -36,4 +36,5 @@ includes:
 - path: changesets/37_delete_client_scope_mappers.yml
 - path: changesets/38_update_keycloak_provider.yml
 - path: changesets/39_update_identity_provider.yml
-- path: changesets/40_add_identity_provider_mapper.yml
+- path: changesets/40_add_identity_provider_mappers.yml
+- path: changesets/41_delete_identity_provider_mappers.yml


### PR DESCRIPTION
Support deletion of idp mappers.

Plus small improvement in the name functions of the add idp mapper actions.