### PR TITLE
Add the possibility to login via browser to execute migrations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ fun Project.command(cmd: List<String>, workingDirectory: String = ".", environme
     }
 
 plugins {
-    kotlin("jvm") version "1.5.32"
+    kotlin("jvm") version "1.6.21"
     id("maven-publish")
     id("signing")
     id("de.undercouch.download") version ("3.4.3")

--- a/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/KeycloakClientInit.kt
+++ b/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/KeycloakClientInit.kt
@@ -25,11 +25,15 @@ import java.time.Duration
  * @param realm Realm to use for the login of the user
  * @param clientId id of the client to use for the login of the user
  */
-fun initKeycloakClient(baseUrl: String, adminUser: String, adminPassword: String, realm: String,
+fun initKeycloakClient(baseUrl: String, adminUser: String, adminPassword: String,
+                       adminUseOauth: Boolean, adminUseOauthLocalPort: Int,
+                       realm: String,
     clientId: String, logger: Logger? = null, totp: String = "", tokenOffsetMs: Long = 1000) = initObjectMapper().let {
     TokenHolder(
         initKeycloakLoginClient(baseUrl, logger),
-        adminUser, adminPassword, realm, clientId, totp, tokenOffsetMs
+        adminUser, adminPassword,
+        adminUseOauth, adminUseOauthLocalPort, baseUrl,
+        realm, clientId, totp, tokenOffsetMs
     ).let {
         initKeycloakClientWithTokenHolder(baseUrl, logger, it)
     }

--- a/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/KeycloakLoginClient.kt
+++ b/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/KeycloakLoginClient.kt
@@ -25,5 +25,16 @@ interface KeycloakLoginClient {
     fun login(@Param("realm") realm: String,
         @Param("grant_type") grantType: String,
         @Param("refresh_token") refreshToken: String,
-        @Param("client_id") clientId: String): AccessToken
+        @Param("client_id") clientId: String)
+    : AccessToken
+
+    @RequestLine("POST /realms/{realm}/protocol/openid-connect/token")
+    @Headers("Content-Type: application/x-www-form-urlencoded; charset=UTF-8")
+    fun login(@Param("realm") realm: String,
+        @Param("grant_type") grantType: String,
+        @Param("code") code: String,
+        @Param("client_id") clientId: String,
+        @Param("redirect_uri") redirectUri: String
+    ): AccessToken
+
 }

--- a/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/TokenHolder.kt
+++ b/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/TokenHolder.kt
@@ -1,9 +1,17 @@
 package de.klg71.keycloakmigration.keycloakapi
 
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
 import de.klg71.keycloakmigration.keycloakapi.model.AccessToken
 import org.slf4j.LoggerFactory
+import java.awt.Desktop
+import java.io.IOException
 import java.lang.System.currentTimeMillis
 import java.lang.System.nanoTime
+import java.net.InetSocketAddress
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 /**
@@ -11,6 +19,8 @@ import java.util.concurrent.TimeUnit
  */
 internal class TokenHolder(private val client: KeycloakLoginClient,
     private val adminUser: String, private val adminPassword: String,
+    private val adminUseOauth: Boolean, private val adminUseOauthLocalPort: Int,
+    private val baseUrl: String,
     private val realm: String, private val clientId: String,
     private val totp: String, private val tokenRefreshOffsetMs: Long = 1000) {
 
@@ -18,7 +28,7 @@ internal class TokenHolder(private val client: KeycloakLoginClient,
         val LOG = LoggerFactory.getLogger(TokenHolder::class.java)!!
     }
 
-    private var token: AccessToken = client.login(realm, "password", clientId, adminUser, adminPassword, totp)
+    private var token: AccessToken = initialLogin()
     private var tokenReceived: Long = currentTimeMillis()
     private var tokenReceivedNs: Long = nanoTime()
 
@@ -43,6 +53,67 @@ internal class TokenHolder(private val client: KeycloakLoginClient,
         client.login(realm, "refresh_token", token.refreshToken, clientId)
     } else {
         LOG.info("using password")
-        client.login(realm, "password", clientId, adminUser, adminPassword, totp)
+        initialLogin()
+    }
+
+    private fun initialLogin(): AccessToken {
+        return if (adminUseOauth)
+            loginWithOauth()
+        else
+            client.login(realm, "password", clientId, adminUser, adminPassword, totp)
+    }
+
+    private fun loginWithOauth(): AccessToken {
+        try {
+            val latch = CountDownLatch(1)
+            val server = HttpServer.create(InetSocketAddress(adminUseOauthLocalPort), 0)
+
+            val authUrl = "$baseUrl/realms/$realm/protocol/openid-connect/auth"
+            val redirectUri = "http://localhost:${adminUseOauthLocalPort}/auth_callback"
+            val authRequestUri = "$authUrl?response_type=code&client_id=$clientId&redirect_uri=$redirectUri"
+
+            var accessToken: AccessToken? = null
+            server.createContext("/auth_callback") { exchange: HttpExchange ->
+                val code =
+                    exchange.requestURI.query.split("&")
+                        .first { it.startsWith("code=") }
+                        .substringAfter("=")
+
+                accessToken = client.login(
+                    realm = realm,
+                    grantType = "authorization_code",
+                    code = code,
+                    clientId = clientId,
+                    redirectUri = redirectUri
+                )
+
+                val response =
+                    "Success! Authentication completed. You can close this browser tab and return to the terminal window."
+
+                exchange.sendResponseHeaders(200, response.length.toLong())
+                exchange.responseBody.write(response.toByteArray(StandardCharsets.UTF_8))
+                latch.countDown()
+            }
+            server.start()
+
+            if (Desktop.isDesktopSupported()) {
+                Desktop.getDesktop().browse(URI(authRequestUri))
+            } else {
+                println("Please open the following URL in your browser: $authRequestUri")
+            }
+
+            println("Waiting for redirect URI...")
+            latch.await(2, TimeUnit.MINUTES)
+            server.stop(0)
+
+            accessToken?.let {
+                println("Success! You are now authenticated!")
+                return it
+            } ?: throw RuntimeException("Login via browser failed or took too long")
+        } catch (e: IOException) {
+            throw RuntimeException(e)
+        } catch (e: InterruptedException) {
+            throw RuntimeException(e)
+        }
     }
 }

--- a/keycloakapi/src/test/kotlin/SendEmailTest.kt
+++ b/keycloakapi/src/test/kotlin/SendEmailTest.kt
@@ -10,7 +10,7 @@ internal class SendEmailTest {
 
     // @Test
     fun testSendEmail() {
-        val client = initKeycloakClient("http://localhost:18080/auth", "admin", "admin", "master", "admin-cli")
+        val client = initKeycloakClient("http://localhost:18080/auth", "admin", "admin", false, 8081, "master", "admin-cli")
         if (client.realmNames().map { it.realm }.contains("sendMail")) {
             client.deleteRealm("sendMail")
         }

--- a/keycloakapi/src/test/kotlin/TokenFlakinessTest.kt
+++ b/keycloakapi/src/test/kotlin/TokenFlakinessTest.kt
@@ -29,8 +29,10 @@ class TokenFlakinessTest {
         val realmName = "master"
         val clientId = "admin-cli"
         val adminPassword = "admin"
+        val adminUseOauth = false
+        val adminUseOauthLocalPort = 8081
         val tokenHolder =
-            TokenHolder(initKeycloakLoginClient(baseUrl), adminUser, adminPassword, realmName, clientId, "", 0)
+            TokenHolder(initKeycloakLoginClient(baseUrl), adminUser, adminPassword, adminUseOauth, adminUseOauthLocalPort, baseUrl, realmName, clientId, "", 0)
         val configureClient = initKeycloakClientWithTokenHolder(baseUrl, tokenHolder = tokenHolder)
         val realm = configureClient.realmById(realmName)
         val updatedRealm = RealmUpdateBuilder(realm).run {
@@ -43,7 +45,7 @@ class TokenFlakinessTest {
         repeat(10000) {
             val preTokenTestDurationBeforeStartNs = 4
             val client =
-                initKeycloakClient(baseUrl, adminUser, adminPassword, realmName, clientId, null, "", 20)
+                initKeycloakClient(baseUrl, adminUser, adminPassword, adminUseOauth, adminUseOauthLocalPort, realmName, clientId, null, "", 20)
             val testCallStartTimeMs =
                 currentTimeMillis() + TimeUnit.SECONDS.toMillis(
                     tokenHolder.token().expiresIn

--- a/plugin/src/main/kotlin/de/klg71/keycloakmigrationplugin/GradleMigrationArgs.kt
+++ b/plugin/src/main/kotlin/de/klg71/keycloakmigrationplugin/GradleMigrationArgs.kt
@@ -5,6 +5,8 @@ import de.klg71.keycloakmigration.MigrationArgs
 open class GradleMigrationArgs(private val adminUser: String,
     private val adminPassword: String,
     private val adminTotp: String,
+    private val adminUseOauth: Boolean,
+    private val adminUseOauthLocalPort: Int,
     private val migrationFile: String, private val baseUrl: String,
     private val realm: String, private val clientId: String,
     private val correctHashes: Boolean,
@@ -17,6 +19,8 @@ open class GradleMigrationArgs(private val adminUser: String,
     override fun adminUser() = adminUser
     override fun adminPassword() = adminPassword
     override fun adminTotp() = adminTotp
+    override fun adminUseOauth() = adminUseOauth
+    override fun adminUseOauthLocalPort() = adminUseOauthLocalPort
     override fun baseUrl() = baseUrl
     override fun migrationFile() = migrationFile
     override fun parameters() = parameters

--- a/plugin/src/main/kotlin/de/klg71/keycloakmigrationplugin/KeycloakMigrationCorrectHashesTask.kt
+++ b/plugin/src/main/kotlin/de/klg71/keycloakmigrationplugin/KeycloakMigrationCorrectHashesTask.kt
@@ -16,6 +16,12 @@ open class KeycloakMigrationCorrectHashesTask : DefaultTask() {
     var adminTotp = ""
 
     @Input
+    var adminUseOauth = false
+
+    @Input
+    var adminUseOauthLocalPort = 8081
+
+    @Input
     var migrationFile = "keycloak-changelog.yml"
 
     @Input
@@ -46,6 +52,7 @@ open class KeycloakMigrationCorrectHashesTask : DefaultTask() {
     @TaskAction
     fun migrate() {
         GradleMigrationArgs(adminUser, adminPassword,adminTotp,
+                adminUseOauth, adminUseOauthLocalPort,
                 Paths.get(project.projectDir.toString(), migrationFile).toString(),
                 baseUrl, realm, clientId, true,
                 parameters, waitForKeycloak, waitForKeycloakTimeout, failOnUndefinedVariables, warnOnUndefinedVariables)

--- a/plugin/src/main/kotlin/de/klg71/keycloakmigrationplugin/KeycloakMigrationTask.kt
+++ b/plugin/src/main/kotlin/de/klg71/keycloakmigrationplugin/KeycloakMigrationTask.kt
@@ -16,6 +16,12 @@ open class KeycloakMigrationTask : DefaultTask() {
     var adminTotp = ""
 
     @Input
+    var adminUseOauth = false
+
+    @Input
+    var adminUseOauthLocalPort = 8081
+
+    @Input
     var migrationFile = "keycloak-changelog.yml"
 
     @Input
@@ -47,6 +53,7 @@ open class KeycloakMigrationTask : DefaultTask() {
     fun migrate() {
         GradleMigrationArgs(
             adminUser, adminPassword, adminTotp,
+            adminUseOauth, adminUseOauthLocalPort,
             Paths.get(project.projectDir.toString(), migrationFile).toString(),
             baseUrl, realm, clientId, false,
             parameters, waitForKeycloak, waitForKeycloakTimeout, failOnUndefinedVariables, warnOnUndefinedVariables

--- a/src/main/kotlin/de/klg71/keycloakmigration/CommandLineMigrationArgs.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/CommandLineMigrationArgs.kt
@@ -7,6 +7,8 @@ import com.xenomachina.argparser.default
 const val DEFAULT_CHANGELOGFILE = "keycloak-changelog.yml"
 const val DEFAULT_ADMIN_USER = "admin"
 const val DEFAULT_ADMIN_PASSWORD = "admin"
+const val DEFAULT_ADMIN_USE_OAUTH = false
+const val DEFAULT_ADMIN_USE_OAUTH_LOCAL_PORT = 8081
 const val DEFAULT_KEYCLOAK_SERVER = "http://localhost:8080/auth"
 const val DEFAULT_REALM = "master"
 const val DEFAULT_CLIENTID = "admin-cli"
@@ -36,6 +38,18 @@ internal class CommandLineMigrationArgs(parser: ArgParser) :
         help = "Time based one time password for the migration user, empty per default"
     )
         .default(DEFAULT_ADMIN_PASSWORD)
+
+    private val adminUseOauth by parser.flagging(
+        names = arrayOf("-o", "--use-oauth"),
+        help = "Use OAuth2 for login instead of user/pass/(totp), defaulting to $DEFAULT_ADMIN_USE_OAUTH."
+    )
+        .default(DEFAULT_ADMIN_USE_OAUTH)
+
+    private val adminUseOauthLocalPort by parser.counting(
+        names = arrayOf("-P", "--use-oauth-local-port"),
+        help = "Which port to listen for the auth code callback, defaulting to $DEFAULT_ADMIN_USE_OAUTH_LOCAL_PORT."
+    )
+        .default(DEFAULT_ADMIN_USE_OAUTH_LOCAL_PORT)
 
     private val baseUrl by parser.storing(
         names = arrayOf("-b", "--baseurl"),
@@ -112,6 +126,8 @@ internal class CommandLineMigrationArgs(parser: ArgParser) :
 
     override fun adminPassword() = adminPassword
     override fun adminTotp() = adminTotp
+    override fun adminUseOauth() = adminUseOauth
+    override fun adminUseOauthLocalPort() = adminUseOauthLocalPort
 
     override fun migrationFile() = migrationFile.firstOrNull() ?: DEFAULT_CHANGELOGFILE
 

--- a/src/main/kotlin/de/klg71/keycloakmigration/Configuration.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/Configuration.kt
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.KotlinModule
-import de.klg71.keycloakmigration.changeControl.KeycloakMigration
 import de.klg71.keycloakmigration.changeControl.RealmChecker
 import de.klg71.keycloakmigration.changeControl.StringEnvSubstitutor
 import de.klg71.keycloakmigration.changeControl.actions.Action
@@ -19,7 +18,6 @@ import de.klg71.keycloakmigration.keycloakapi.userByName
 import feign.Logger
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
-import org.slf4j.LoggerFactory
 
 /**
  * Initialize dependency injection and create the beans according to the given parameters
@@ -28,6 +26,8 @@ import org.slf4j.LoggerFactory
 fun myModule(adminUser: String,
     adminPassword: String,
     adminTotp:String,
+    adminUseOauth:Boolean,
+    adminUseOauthLocalPort:Int,
     baseUrl: String,
     realm: String,
     clientId: String,
@@ -38,7 +38,7 @@ fun myModule(adminUser: String,
     single { StringEnvSubstitutor(failOnUndefinedVariabled, warnOnUndefinedVariables) }
     single(named("yamlObjectMapper")) { initYamlObjectMapper() }
     single(named("parameters")) { parameters }
-    single { initKeycloakClient(baseUrl, adminUser, adminPassword, realm, clientId, logger,adminTotp) }
+    single { initKeycloakClient(baseUrl, adminUser, adminPassword, adminUseOauth, adminUseOauthLocalPort, realm, clientId, logger,adminTotp) }
     single(named("migrationUserId")) { loadCurrentUser(get(), adminUser, realm) }
     single { RealmChecker() }
 }

--- a/src/main/kotlin/de/klg71/keycloakmigration/KoinLogger.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/KoinLogger.kt
@@ -14,6 +14,7 @@ class KoinLogger(private val log: org.slf4j.Logger) : Logger() {
             Level.DEBUG -> log.debug(msg)
             Level.ERROR -> log.error(msg)
             Level.INFO -> log.info(msg)
+            Level.NONE -> { }
         }
     }
 

--- a/src/main/kotlin/de/klg71/keycloakmigration/Main.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/Main.kt
@@ -67,7 +67,9 @@ fun migrate(migrationArgs: MigrationArgs) {
                 logger(KoinLogger(KOIN_LOGGER))
                 modules(
                     myModule(
-                        adminUser(), adminPassword(), adminTotp(), baseUrl(), realm(), clientId(), parameters(),
+                        adminUser(), adminPassword(), adminTotp(),
+                        adminUseOauth(), adminUseOauthLocalPort(),
+                        baseUrl(), realm(), clientId(), parameters(),
                         failOnUndefinedVariables(), warnOnUndefinedVariables()
                     )
                 )

--- a/src/main/kotlin/de/klg71/keycloakmigration/MigrationArgs.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/MigrationArgs.kt
@@ -5,6 +5,8 @@ interface MigrationArgs {
     fun adminUser(): String
     fun adminPassword(): String
     fun adminTotp(): String
+    fun adminUseOauth(): Boolean
+    fun adminUseOauthLocalPort(): Int
     fun baseUrl(): String
     fun migrationFile(): String
     fun realm(): String

--- a/src/test/kotlin/de/klg71/keycloakmigration/AbstractIntegrationTest.kt
+++ b/src/test/kotlin/de/klg71/keycloakmigration/AbstractIntegrationTest.kt
@@ -24,7 +24,7 @@ abstract class AbstractIntegrationTest : KoinComponent {
         startKoin {
             modules(
                 myModule(
-                    adminUser, adminPass, "", TEST_BASE_URL, realm, clientId, emptyMap(),
+                    adminUser, adminPass, "", false, 8081, TEST_BASE_URL, realm, clientId, emptyMap(),
                     failOnUndefinedVariabled = true, warnOnUndefinedVariables = true, Slf4jLogger()
                 )
             )
@@ -35,7 +35,7 @@ abstract class AbstractIntegrationTest : KoinComponent {
         startKoin {
             modules(
                 myModule(
-                    adminUser, adminPass, "", TEST_BASE_URL, realm, clientId, parameters,
+                    adminUser, adminPass, "", false, 8081, TEST_BASE_URL, realm, clientId, parameters,
                     failOnUndefinedVariabled = true, warnOnUndefinedVariables = true
                 )
             )

--- a/src/test/kotlin/de/klg71/keycloakmigration/testmigration/TestMigrationArgs.kt
+++ b/src/test/kotlin/de/klg71/keycloakmigration/testmigration/TestMigrationArgs.kt
@@ -2,6 +2,8 @@ package de.klg71.keycloakmigration.testmigration
 
 import de.klg71.keycloakmigration.DEFAULT_ADMIN_PASSWORD
 import de.klg71.keycloakmigration.DEFAULT_ADMIN_USER
+import de.klg71.keycloakmigration.DEFAULT_ADMIN_USE_OAUTH
+import de.klg71.keycloakmigration.DEFAULT_ADMIN_USE_OAUTH_LOCAL_PORT
 import de.klg71.keycloakmigration.DEFAULT_CLIENTID
 import de.klg71.keycloakmigration.DEFAULT_DISABLE_WARN_ON_UNDEFINED_VARIABLES
 import de.klg71.keycloakmigration.DEFAULT_FAIL_ON_UNDEFINED_VARIABLES
@@ -13,11 +15,13 @@ import de.klg71.keycloakmigration.MigrationArgs
 /**
  * executes the changesets from test/resources
  *
- * INFO: This file must has its run configuration working dir set to src/test/resources
+ * INFO: This file must have its run configuration working dir set to src/test/resources
  */
 object TestMigrationArgs : MigrationArgs {
     override fun adminUser() = DEFAULT_ADMIN_USER
     override fun adminPassword() = DEFAULT_ADMIN_PASSWORD
+    override fun adminUseOauth() = DEFAULT_ADMIN_USE_OAUTH
+    override fun adminUseOauthLocalPort() = DEFAULT_ADMIN_USE_OAUTH_LOCAL_PORT
     override fun baseUrl() = "http://localhost:18080/auth"
     override fun migrationFile() = "src/test/resources/keycloak-changelog.yml"
     override fun realm() = DEFAULT_REALM

--- a/src/test/kotlin/de/klg71/keycloakmigration/testmigration/WaitForKeycloakTest.kt
+++ b/src/test/kotlin/de/klg71/keycloakmigration/testmigration/WaitForKeycloakTest.kt
@@ -7,6 +7,8 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import com.github.tomakehurst.wiremock.matching.UrlPattern
 import de.klg71.keycloakmigration.DEFAULT_ADMIN_PASSWORD
 import de.klg71.keycloakmigration.DEFAULT_ADMIN_USER
+import de.klg71.keycloakmigration.DEFAULT_ADMIN_USE_OAUTH
+import de.klg71.keycloakmigration.DEFAULT_ADMIN_USE_OAUTH_LOCAL_PORT
 import de.klg71.keycloakmigration.DEFAULT_CLIENTID
 import de.klg71.keycloakmigration.DEFAULT_DISABLE_WARN_ON_UNDEFINED_VARIABLES
 import de.klg71.keycloakmigration.DEFAULT_FAIL_ON_UNDEFINED_VARIABLES
@@ -14,12 +16,10 @@ import de.klg71.keycloakmigration.DEFAULT_REALM
 import de.klg71.keycloakmigration.KeycloakNotReadyException
 import de.klg71.keycloakmigration.MigrationArgs
 import de.klg71.keycloakmigration.migrate
-import feign.FeignException
 import org.apache.logging.log4j.core.config.Configurator
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import org.koin.core.error.InstanceCreationException
-import java.io.FileNotFoundException
 import java.nio.file.Paths
 
 
@@ -28,6 +28,8 @@ class WaitForKeycloakTest {
     object TestMigrationArgs : MigrationArgs {
         override fun adminUser() = DEFAULT_ADMIN_USER
         override fun adminPassword() = DEFAULT_ADMIN_PASSWORD
+        override fun adminUseOauth() = DEFAULT_ADMIN_USE_OAUTH
+        override fun adminUseOauthLocalPort() = DEFAULT_ADMIN_USE_OAUTH_LOCAL_PORT
         override fun baseUrl() = "http://localhost:8888/auth" // wiremock server
         override fun migrationFile() = "src/test/resources/keycloak-changelog.yml"
         override fun realm() = DEFAULT_REALM


### PR DESCRIPTION
My team wants to avoid shared secrets like the password of the keycloak admin user (which we will keep as it is needed to write the migration hashes to; then the password of that user no longer needs to be shared with the entire team).
Users in our realms come from AzureAD and those who have a certain role there are granted the necessary realm management roles.
With this PR it's possible to login as keycloak admin via the Auth Code Flow, i.e. a browser opens and sends the code via auth_callback to the keycloakmigration plugin that then exchanges the code for an actual access token.

BTW, this was the background for my question in issue #86 and I was able to successfully test this on Windows.