### PR TITLE
Add ability to update client's secret

### DIFF
--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/client/UpdateClientAction.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/client/UpdateClientAction.kt
@@ -18,6 +18,7 @@ class UpdateClientAction(
     private val clientAuthenticatorType: String? = null,
     private val attributes: Map<String, String>? = null,
     private val protocol: String? = null,
+    private val secret: String? = null,
     private val redirectUris: List<String>? = null,
     private val notBefore: Int? = null,
     private val bearerOnly: Boolean? = null,
@@ -76,7 +77,7 @@ class UpdateClientAction(
         oldClient.access,
         baseUrl ?: oldClient.baseUrl,
         adminUrl ?: oldClient.adminUrl,
-        oldClient.secret,
+        secret ?: oldClient.secret,
         rootUrl ?: oldClient.rootUrl
     )
 

--- a/src/test/kotlin/de/klg71/keycloakmigration/changeControl/actions/client/UpdateClientIntegTest.kt
+++ b/src/test/kotlin/de/klg71/keycloakmigration/changeControl/actions/client/UpdateClientIntegTest.kt
@@ -121,4 +121,15 @@ class UpdateClientIntegTest : AbstractIntegrationTest() {
         assertThat(clientAfter.surrogateAuthRequired).isTrue
     }
 
+    @Test
+    fun testUpdateClient_secret() {
+        AddSimpleClientAction(testRealm, "simpleClient").executeIt()
+        val clientBefore = client.clientById("simpleClient", testRealm)
+        assertThat(clientBefore.secret).isNullOrEmpty()
+
+        UpdateClientAction(testRealm, "simpleClient", publicClient = false, secret = "secret").executeIt()
+        val clientAfter = client.clientById("simpleClient", testRealm)
+        assertThat(clientAfter.secret).isEqualTo("secret")
+    }
+
 }


### PR DESCRIPTION
This PR allows developers to write a migration that would update secret of an existing client.