### PR TITLE
added `notContainsUsername` password policy

### DIFF
--- a/docsbuild/content/migrations/realm.md
+++ b/docsbuild/content/migrations/realm.md
@@ -175,6 +175,7 @@ Supported policies:
  - hashingAlgorithm
  - hashAlgorithm
  - notUsername
+ - notContainsUsername
  - notEmail
 
 See example below

--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/realm/UpdateRealmAction.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/realm/UpdateRealmAction.kt
@@ -202,6 +202,7 @@ class UpdateRealmAction(
     private fun mapValue(entry: Map.Entry<String, String>) =
         when (entry.key.lowercase()) {
             "notusername" -> "undefined"
+            "notcontainsusername" -> "undefined"
             "notemail" -> "undefined"
             else -> entry.value
         }
@@ -229,6 +230,7 @@ class UpdateRealmAction(
         "hashingalgorithm" -> "hashAlgorithm"
         "hashalgorithm" -> "hashAlgorithm"
         "notusername" -> "notUsername"
+        "notcontainsusername" -> "notContainsUsername"
         "notemail" -> "notEmail"
         else -> throw MigrationException("Not recognized policy: ${entry.key}")
     }


### PR DESCRIPTION
Added support for the password policy `notContainsUsername` which configures keycloak to not allow any passwords which contains the user's username as a substring of the password.