### PR TITLE
:memo: Fix documentation 

### DIFF
--- a/docsbuild/content/migrations/client.md
+++ b/docsbuild/content/migrations/client.md
@@ -395,9 +395,13 @@ Imports authorization configuration using the JSON representation
 ```yaml
     id: import-client-authorization
     author: devtobi
+    realm: integ-test
     changes:
-    - importClientAuthorization:
-          realm: master
+      - addSimpleClient:
+          clientId: test
+          serviceAccountsEnabled: true
+          authorizationServicesEnabled: true
+      - importClientAuthorization:
           clientId: test
           authorizationRepresentationJsonFilename: authorization.json
           relativeToFile: true

--- a/docsbuild/content/migrations/client.md
+++ b/docsbuild/content/migrations/client.md
@@ -19,7 +19,7 @@ Simple command to add a client to keycloak, TODO: add more fields
 - publicClient: Boolean, optional, default=true
 - redirectUris: List< String>, optional, default=empty
 - authorizationServicesEnabled: Boolean, optional, default=false
-- serviceAccountsEnabled: BOolean, optional, default=true
+- serviceAccountsEnabled: Boolean, optional, default=true
 ### Example
 ```yaml
     id: add-simple-client
@@ -387,7 +387,8 @@ Imports authorization configuration using the JSON representation
 
 ### Parameters
 - realm: String, optional
-- clientRepresentationJsonFilename: String, not optional
+- clientId: String, not optional
+- authorizationRepresentationJsonFilename: String, not optional
 - relativeToFile: Boolean, optional, default=true
 
 ### Example:
@@ -395,8 +396,9 @@ Imports authorization configuration using the JSON representation
     id: import-client-authorization
     author: devtobi
     changes:
-    - importClient:
+    - importClientAuthorization:
           realm: master
+          clientId: test
           authorizationRepresentationJsonFilename: authorization.json
           relativeToFile: true
 ```


### PR DESCRIPTION
# Changes
- Fixed documentation for importClientAuthorization and addSimpleClient

This is a follow up of https://github.com/mayope/keycloakmigration/pull/101.