### PR TITLE
AddFlowExecution: Delegate `parentFlow` Validation

### DIFF
--- a/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/KeycloakClientHelper.kt
+++ b/keycloakapi/src/main/kotlin/de/klg71/keycloakmigration/keycloakapi/KeycloakClientHelper.kt
@@ -2,6 +2,10 @@
 
 package de.klg71.keycloakmigration.keycloakapi
 
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import de.klg71.keycloakmigration.keycloakapi.model.Client
 import de.klg71.keycloakmigration.keycloakapi.model.ClientScope
 import de.klg71.keycloakmigration.keycloakapi.model.GroupListItem
@@ -179,8 +183,19 @@ fun Response.isSuccessful() = when (status()) {
 
 fun Response.extractLocationUUID(): UUID {
     if (!isSuccessful()) {
-        throw KeycloakApiException(this.body().asReader().readText(), statusCode = status())
+        var message = this.body().asReader(Charsets.UTF_8).readText()
+
+        try {
+            val body = jacksonObjectMapper().readValue(message, object : TypeReference<Map<String, String>>() {})
+
+            if (body.containsKey("error")) throw KeycloakApiException(body["error"].toString())
+        } catch (e: JsonProcessingException) {
+        } catch (e: JsonMappingException) {
+        }
+
+        throw KeycloakApiException(message, statusCode = status())
     }
+
     return headers()["location"]!!.first()
         .run {
             split("/").last()
@@ -260,11 +275,11 @@ fun KeycloakClient.identityProviderMapperExistsByName(identityProviderAlias: Str
     identityProviderMappers(realm, identityProviderAlias).any { it.name == name }
 
 fun KeycloakClient.organizationByName(name: String, realm: String): Organization = organizations(realm).run {
-        if (isEmpty()) {
-            throw KeycloakApiException("Organization with name: $name does not exist in $realm!")
-        }
-        find { it.name == name }?.let {
-            return it
-        }
-        throw KeycloakApiException("Organization with name: $name does not exist in realm: $realm!")
+    if (isEmpty()) {
+        throw KeycloakApiException("Organization with name: $name does not exist in $realm!")
     }
+    find { it.name == name }?.let {
+        return it
+    }
+    throw KeycloakApiException("Organization with name: $name does not exist in realm: $realm!")
+}

--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/flow/AddFlowExecutionAction.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/actions/flow/AddFlowExecutionAction.kt
@@ -1,7 +1,6 @@
 package de.klg71.keycloakmigration.changeControl.actions.flow
 
 import de.klg71.keycloakmigration.changeControl.actions.Action
-import de.klg71.keycloakmigration.changeControl.actions.MigrationException
 import de.klg71.keycloakmigration.keycloakapi.extractLocationUUID
 import de.klg71.keycloakmigration.keycloakapi.model.AddFlowExecution
 import de.klg71.keycloakmigration.keycloakapi.model.AuthenticatorConfig
@@ -18,10 +17,6 @@ class AddFlowExecutionAction(
     private lateinit var executionId: UUID
 
     override fun execute() {
-        if (client.flows(realm()).none { it.alias == flowAlias }) {
-            throw MigrationException("Parent flow $flowAlias doesn't exist")
-        }
-
         executionId = client.addFlowExecution(realm(), flowAlias, AddFlowExecution(provider)).extractLocationUUID()
 
         if (config.isNotEmpty())

--- a/src/test/kotlin/de/klg71/keycloakmigration/changeControl/actions/flow/AddFlowExecutionIntegTest.kt
+++ b/src/test/kotlin/de/klg71/keycloakmigration/changeControl/actions/flow/AddFlowExecutionIntegTest.kt
@@ -55,7 +55,7 @@ class AddFlowExecutionIntegTest : AbstractIntegrationTest() {
                 provider = "deny-access-authenticator",
                 executionAlias = "Deny Access"
             ).executeIt()
-        }.isInstanceOf(KeycloakApiException::class.java).hasMessage("Parent flow doesn't exist")
+        }.isInstanceOf(KeycloakApiException::class.java).hasMessageContaining("Parent flow doesn't exist")
     }
 
 }

--- a/src/test/kotlin/de/klg71/keycloakmigration/changeControl/actions/flow/AddFlowExecutionIntegTest.kt
+++ b/src/test/kotlin/de/klg71/keycloakmigration/changeControl/actions/flow/AddFlowExecutionIntegTest.kt
@@ -1,7 +1,7 @@
 package de.klg71.keycloakmigration.changeControl.actions.flow
 
 import de.klg71.keycloakmigration.AbstractIntegrationTest
-import de.klg71.keycloakmigration.changeControl.actions.MigrationException
+import de.klg71.keycloakmigration.keycloakapi.KeycloakApiException
 import de.klg71.keycloakmigration.keycloakapi.KeycloakClient
 import de.klg71.keycloakmigration.keycloakapi.model.AuthenticationExecutionImport
 import de.klg71.keycloakmigration.keycloakapi.model.Flow
@@ -48,16 +48,14 @@ class AddFlowExecutionIntegTest : AbstractIntegrationTest() {
 
     @Test
     fun testAddFlowExecution_NotExisting() {
-        val alias = "TestFlow"
-
         assertThatThrownBy {
             AddFlowExecutionAction(
                 testRealm,
-                flowAlias = alias,
+                flowAlias = "TestFlow",
                 provider = "deny-access-authenticator",
                 executionAlias = "Deny Access"
             ).executeIt()
-        }.isInstanceOf(MigrationException::class.java).hasMessage("Parent flow $alias doesn't exist")
+        }.isInstanceOf(KeycloakApiException::class.java).hasMessage("Parent flow doesn't exist")
     }
 
 }


### PR DESCRIPTION
This pull request addresses two key improvements to the `AddFlowExecution` logic within the Keycloak migration project.

**1. ParentFlow Validation:**
* The client-side validation of `parentFlow` was incorrect, leading to issues with subflow migration.
* This fix delegates parentFlow validation to Keycloak's built-in mechanisms, ensuring consistency and correctness.
