### PR TITLE
Replace slf4j2-impl with slf4j2-impl2 for slf4j API 2.x support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
     implementation("org.slf4j:slf4j-api:2.0.16")
     implementation("io.insert-koin:koin-logger-slf4j:4.0.2")
     implementation("org.apache.logging.log4j:log4j-core:2.24.3")
-    runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.24.3")
+    runtimeOnly("org.apache.logging.log4j:log4j-slf4j2-impl:2.24.3")
 
     testImplementation("io.github.openfeign:feign-slf4j:13.5")
     testImplementation(kotlin("test"))

--- a/keycloakapi/build.gradle.kts
+++ b/keycloakapi/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
 
     testImplementation("org.slf4j:slf4j-api:2.0.16")
     testImplementation("org.apache.logging.log4j:log4j-core:2.24.3")
-    testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.24.3")
+    testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j2-impl:2.24.3")
 
     testImplementation(kotlin("test"))
     testImplementation(kotlin("test-junit"))


### PR DESCRIPTION
This pull request addresses a dependency incompatibility issue with `org.slf4j:slf4j-api:2.X.X`.

The current dependency `slf4j2-impl` is not compatible with slf4j API version 2.x. This change replaces it with `slf4j2-impl2`, which is the correct implementation dependency for slf4j API 2.x.

This ensures proper logging functionality when using slf4j API 2.x.